### PR TITLE
updating to remove dependency on exception-notification gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ end
 
 gem "unicorn", '4.3.1'
 gem "router-client", '3.1.0', :require => false
-gem "exception_notification"
 gem "aws-ses", :require => 'aws/ses'
 gem "plek", "0.3.0" # Used in exception_notification config
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,8 +55,6 @@ GEM
     diff-lcs (1.1.3)
     erubis (2.7.0)
     eventmachine (1.0.0)
-    exception_notification (2.6.1)
-      actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     faraday (0.8.4)
@@ -207,7 +205,6 @@ DEPENDENCIES
   airbrake (= 3.1.5)
   aws-ses
   capybara (= 1.1.2)
-  exception_notification
   govuk_frontend_toolkit (= 0.6.2)
   plek (= 0.3.0)
   poltergeist (= 0.7.0)

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,5 +1,0 @@
-Rails.application.config.middleware.use ExceptionNotifier,
-  :email_prefix => "[#{Rails.application.class.name.split('::').first} (#{Plek.current.environment})] ",
-  :sender_address => %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
-  :exception_recipients => %w{govuk-exceptions@digital.cabinet-office.gov.uk}
-


### PR DESCRIPTION
As part of rolling out Errbit we're removing exception-notifier.
