### PR TITLE
improving error msgs when problem raising ticket

### DIFF
--- a/lib/zendesk_error.rb
+++ b/lib/zendesk_error.rb
@@ -1,0 +1,1 @@
+class ZendeskError < StandardError; end


### PR DESCRIPTION
Right now, when raising the ticket in Zendesk fails, there's a very generic exception that doesn't point to the cause of the problem. This change introduces better error messaging.
