### PR TITLE
Disable formatted routes.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,12 @@ Feedback::Application.routes.draw do
 
   # See how all your routes lay out with "rake routes"
 
-  get "/feedback", :to => redirect("/feedback/contact")
-  post "/feedback", :to => "feedback#report_a_problem_submit"
-  get "/feedback/contact", :to => "feedback#contact"
-  post "/feedback/contact", :to => "feedback#contact_submit"
-  get "/feedback/foi", :to => "feedback#foi"
-  post "/feedback/foi", :to => "feedback#foi_submit"
+  get "/feedback", :to => redirect("/feedback/contact"), :format => false
+  post "/feedback", :to => "feedback#report_a_problem_submit", :format => false
+  get "/feedback/contact", :to => "feedback#contact", :format => false
+  post "/feedback/contact", :to => "feedback#contact_submit", :format => false
+  get "/feedback/foi", :to => "feedback#foi", :format => false
+  post "/feedback/foi", :to => "feedback#foi_submit", :format => false
 
   root :to => redirect("/feedback", :status => 302)
 


### PR DESCRIPTION
This will prevent requests for e.g. /feedback/contact.json from raising
500 errors.  They'll now just 404.
