### PR TITLE
increasing maximum allowed serverside char count

### DIFF
--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -5,12 +5,12 @@ class ContactTicket < Ticket
                 :javascript_enabled
 
   validate :validate_link
-  validates_length_of :link, :maximum => 1200, :message => "The page field can be max 1200 characters"
+  validates_length_of :link, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The page field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
   validates_presence_of :textdetails, :message => "The message field cannot be empty"
-  validates_length_of :textdetails, :maximum => 1200, :message => "The message field can be max 1200 characters"
-  validates_length_of :name, :maximum => 1200, :message => "The name field can be max 1200 characters"
+  validates_length_of :textdetails, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The message field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
+  validates_length_of :name, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The name field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
   validates_format_of :email, :with => /\A\z|\A[\w\d]+[^@]*@[\w\d]+[^@]*\.[\w\d]+[^@]*\z/, :message => "The email address must be valid"
-  validates_length_of :email, :maximum => 1200, :message => "The email field can be max 1200 characters"
+  validates_length_of :email, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The email field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
   validate :validate_mail_name_connection
 
   def javascript_enabled

--- a/app/models/foi_ticket.rb
+++ b/app/models/foi_ticket.rb
@@ -7,7 +7,7 @@ class FoiTicket < Ticket
   validates_format_of :email, :with => /\A[\w\d]+[^@]*@[\w\d]+[^@]*\.[\w\d]+[^@]*\z/, :message => "The email address must be valid"
   validates_confirmation_of :email, :message => "The two email addresses must match"
   validates_presence_of :textdetails, :message => "The message field cannot be empty"
-  validates_length_of :textdetails, :maximum => 1200, :message => "The message field can be max 1200 characters"
+  validates_length_of :textdetails, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The message field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
 
   private
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,6 +2,12 @@ class Ticket
   include ActiveModel::Validations
   attr_accessor :val
 
+  # This is deliberately higher than the max character count
+  # in the front-end (javascript and maxlength in the markup),
+  # because certain browsers treat "\r\n" incorrectly as
+  # 1 character long.
+  FIELD_MAXIMUM_CHARACTER_COUNT = 1250
+
   validate :validate_val
 
   def initialize(attributes = {})

--- a/spec/models/contact_ticket_spec.rb
+++ b/spec/models/contact_ticket_spec.rb
@@ -14,7 +14,7 @@ describe ContactTicket do
   end
 
   it "should return contact error with too long name" do
-    name = build_random_string 1201
+    name = build_random_string 1251
     test_data = {
         name: name,
         email: "a@a",
@@ -36,7 +36,7 @@ describe ContactTicket do
   end
 
   it "should return contact error with too long email" do
-    email = (build_random_string 1201) + "@a.com"
+    email = (build_random_string 1251) + "@a.com"
     test_data = {
         name: "test name",
         email: email,
@@ -47,7 +47,7 @@ describe ContactTicket do
   end
 
   it "should return contact error with location specific but without link" do
-    textdetails = build_random_string 1201
+    textdetails = build_random_string 1251
     test_data = {
       name: "test name",
       email: "a@a",
@@ -59,7 +59,7 @@ describe ContactTicket do
   end
 
   it "should return contact error with too long textdetails" do
-    textdetails = build_random_string 1201
+    textdetails = build_random_string 1251
     test_data = {
       name: "test name",
       email: "a@a",

--- a/spec/models/foi_ticket_spec.rb
+++ b/spec/models/foi_ticket_spec.rb
@@ -70,7 +70,7 @@ describe FoiTicket do
   end
 
   it "should return foi error with too long foi text" do
-    textdetails = build_random_string 1201
+    textdetails = build_random_string 1251
     test_data = {
         name: "test name",
         email: "a@a",


### PR DESCRIPTION
This change is in response to [Zendesk ticket 43023](https://govuk.zendesk.com/agent/#/tickets/43023).

Before this change, there is a 1200 char limit on certain form fields
within both the frontend (JS, templates) and the backend (models).
However, because some browers treat "\r\n" as 1 char, it is possible
to create a submission that the frontend allows but fails the server-
side validation. This is somewhat confusing to the users.

To work around this, this change bumps the model validations to 1250
chars.
