### PR TITLE
prevent double submit in JS

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -68,8 +68,9 @@ GOVUK.feedback.init = function () {
     GOVUK.feedback.checkRadio();
     GOVUK.feedback.prepopulateLinkWithReferrer();
 
-    $('form.contact-form').on("submit", function() {
-        $('button.button').attr('disabled', 'disabled');
+    $('button.button').click(function() {
+        $(this).attr('disabled', 'disabled');
+        $(this).parents('form').submit();
     });
 
     $('#location input').change(function () {


### PR DESCRIPTION
unfortunately, it seems that #33 doesn't work in all cases, as we are still seeing duplicate submissions on the public form.

Going on suggestions from @tombye and @KushalP , this PR disables the submit button upon button click rather than form submit.
