### PR TITLE
prepopulate contact form for service manual users

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -58,15 +58,20 @@ GOVUK.feedback.checkRadio = function () {
     }
 }
 
-GOVUK.feedback.prepopulateLinkWithReferrer = function () {
+GOVUK.feedback.prepopulateFormBasedOnReferrer = function () {
     $('#link').val(document.referrer);
+    // special handling for the service manual as it's not strictly a section on GOV.UK
+    if (document.referrer.indexOf("service-manual") >= 0) {
+        $('#location-section').click();
+        $('#contact_section').val("dbdss");
+    }
 }
 
 GOVUK.feedback.init = function () {
     GOVUK.feedback.initCounters();
     GOVUK.feedback.initUserDetails();
     GOVUK.feedback.checkRadio();
-    GOVUK.feedback.prepopulateLinkWithReferrer();
+    GOVUK.feedback.prepopulateFormBasedOnReferrer();
 
     $('button.button').click(function() {
         $(this).attr('disabled', 'disabled');


### PR DESCRIPTION
For users coming to the public feedback form from the Digital
By Default Service Manual, the Service Manual will be selected
in the section dropdown.
