### PR TITLE
Revert to using ExceptionNotification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,12 @@ end
 
 gem "unicorn", '4.3.1'
 gem "router-client", '3.1.0', :require => false
+
+gem "exception_notification", '2.6.1'
 gem "aws-ses", :require => 'aws/ses'
 gem "plek", "1.1.0" # Used in exception_notification config
 
 gem "zendesk_api", '0.1.2'
-
-gem "airbrake", '3.1.5'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,9 +31,6 @@ GEM
       i18n (= 0.6.1)
       multi_json (~> 1.0)
     addressable (2.3.2)
-    airbrake (3.1.5)
-      builder
-      girl_friday
     arel (3.0.2)
     aws-ses (0.4.4)
       builder
@@ -50,11 +47,12 @@ GEM
       xpath (~> 0.1.4)
     childprocess (0.3.5)
       ffi (~> 1.0, >= 1.0.6)
-    connection_pool (0.9.2)
     crack (0.3.1)
     diff-lcs (1.1.3)
     erubis (2.7.0)
     eventmachine (1.0.0)
+    exception_notification (2.6.1)
+      actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     faraday (0.8.4)
@@ -64,8 +62,6 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.1.5)
-    girl_friday (0.10.0)
-      connection_pool (~> 0.9.0)
     govuk_frontend_toolkit (0.6.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
@@ -203,9 +199,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (= 3.1.5)
   aws-ses
   capybara (= 1.1.2)
+  exception_notification (= 2.6.1)
   govuk_frontend_toolkit (= 0.6.2)
   plek (= 1.1.0)
   poltergeist (= 0.7.0)

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -28,7 +28,7 @@ class Ticket
       rescue => e
         ticket = nil
         @errors.add :connection, "Connection error"
-        Airbrake.notify(e)
+        ExceptionNotifier::Notifier.background_exception_notification(e).deliver
       end
     end
     ticket

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,0 +1,6 @@
+# This file overwritten on deployment
+
+Rails.application.config.middleware.use ExceptionNotifier,
+  :email_prefix => "[Feedback (development)] ",
+  :sender_address => %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
+  :exception_recipients => %w{govuk-exceptions@digital.cabinet-office.gov.uk}

--- a/spec/models/foi_ticket_spec.rb
+++ b/spec/models/foi_ticket_spec.rb
@@ -81,7 +81,7 @@ describe FoiTicket do
     (ticket.errors.has_key? :textdetails).should eq true
   end
 
-  it "should notify airbrake if zendesk ticket creation fails" do
+  it "should send an exception email if zendesk ticket creation fails" do
     test_data = {
          name: "test name",
          email: "a@a.com",
@@ -90,7 +90,8 @@ describe FoiTicket do
      }
      ticket = FoiTicket.new test_data
      ticket.stub(:ticket_client).and_raise('some error')
-     Airbrake.should_receive(:notify)
      ticket.save
+     ActionMailer::Base.deliveries.last.to.should == ["govuk-exceptions@digital.cabinet-office.gov.uk"]
+     ActionMailer::Base.deliveries.last.body.should =~ /some error/
   end
 end


### PR DESCRIPTION
This was using airbrake to test the errbit install.  This work doesn't
seem to have been completed, and we're now losing some valuable error
information.

Note: there is a corresponding pull-request in alphagov-deployment (#179) that should be merged first.
