### PR TITLE
Bugfix for missing validations

### DIFF
--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -19,6 +19,7 @@ class ContactTicket < Ticket
   validates_length_of :email, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The email field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
   validate :validate_mail_name_connection
   validates :query, inclusion: { in: REASON_HASH.keys, message: "Please pick a valid reason for contacting us" }
+  validates_presence_of :location, message: "Please tell us what your contact is to do with"
 
   def javascript_enabled
     !! @javascript_enabled

--- a/spec/models/contact_ticket_spec.rb
+++ b/spec/models/contact_ticket_spec.rb
@@ -6,7 +6,8 @@ describe ContactTicket do
   def valid_anonymous_ticket_details
     {
       textdetails: "some text",
-      query: "cant-find"
+      query: "cant-find",
+      location: "all"
     }
   end
 
@@ -81,5 +82,10 @@ describe ContactTicket do
     anon_ticket_with(query: "non-existent").errors.should have_key(:query)
     anon_ticket_with(query: "").errors.should have_key(:query)
     anon_ticket_with(query: nil).errors.should have_key(:query)
+  end
+
+  it "should make sure that a location is present" do
+    anon_ticket_with(location: "").errors.should have_key(:location)
+    anon_ticket_with(location: nil).errors.should have_key(:location)
   end
 end


### PR DESCRIPTION
This PR contains fix for production errors:
- when users don't specify the reason for contacting GDS
- when users don't pick one of the "what's this about" options

This also includes a refactoring of the `contact_ticket_spec.rb` (893bcf7).
