### PR TITLE
another refinement to exception logging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,12 @@ protected
 
   def zendesk_error(exception)
     if exception and Rails.application.config.middleware.detect{ |x| x.klass == ExceptionNotifier }
-      ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver
+      if exception.respond_to?(:errors)
+        message = { data: { message: "Zendesk errors: #{exception.errors}" } }
+        ExceptionNotifier::Notifier.exception_notification(request.env, exception, message).deliver
+      else
+        ExceptionNotifier::Notifier.exception_notification(request.env, exception).deliver
+      end
     end
 
     respond_to do |format|

--- a/lib/ticket_client_dummy.rb
+++ b/lib/ticket_client_dummy.rb
@@ -1,3 +1,5 @@
+require 'zendesk_api/error'
+
 class TicketClientDummy
   class << self
 
@@ -5,6 +7,9 @@ class TicketClientDummy
       if zendesk[:description] =~ /break_zendesk/
         Rails.logger.info "Zendesk ticket creation fail for: #{zendesk.inspect}"
         raise ZendeskDidntCreateTicketError, "Failed to create Zendesk ticket"
+      elsif zendesk[:description] =~ /zendesk validation error/
+        Rails.logger.info "Zendesk ticket validation failure for: #{zendesk.inspect}"
+        raise ZendeskAPI::Error::RecordInvalid.new(body: { "details" => "validation errors" })
       else
         Rails.logger.info "Zendesk ticket created: #{zendesk.inspect}"
         zendesk


### PR DESCRIPTION
the validation exceptions thrown by the `zendesk_api` gem don't
contain the error details in `#to_s`. This change logs the details
from those exceptions using `exception_notifier`.
