### PR TITLE
Add missing labels to feedback form

### DIFF
--- a/app/assets/stylesheets/feedback.scss
+++ b/app/assets/stylesheets/feedback.scss
@@ -29,6 +29,7 @@
 #link{
   width: 64%;
   margin-left: -0.25em;
+  margin-right: 0;
 }
 .contact-form textarea.full-size {
   height: 15em;

--- a/app/views/feedback/contact.html.erb
+++ b/app/views/feedback/contact.html.erb
@@ -37,6 +37,7 @@
       <input type="radio" name="contact[location]" id="location-section" value="section"
         <%= @old ? (@old[:location] == "section" ? "checked" : "" ) : "" %> > A specific section
     </label>
+    <label for="contact_section" class="visuallyhidden">Section</label>
     <%= select_tag "contact[section]", options_for_select(@sections, (@old ? @old[:section] : '')) %>
   </p>
 
@@ -72,6 +73,7 @@
       <span class="validation-message" id="textdetailserror"><%= @errors[:textdetails].first %></span>
     <% end %>
 
+    <label for="textdetails" class="visuallyhidden">Detail</label>
     <textarea name='contact[textdetails]' class="full-size counted" id="textdetails"
               required aria-required="true"><%= (@old ? @old[:textdetails] : '') %></textarea>
 


### PR DESCRIPTION
Add labels to the two form elements on the contact form that are without them.
