### PR TITLE
Whitehall feedback

### DIFF
--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -1,5 +1,5 @@
 class ReportAProblemTicket < Ticket
-  SOURCE_WHITELIST = %w(citizen government specialist page_not_found)
+  SOURCE_WHITELIST = %w(mainstream inside_government page_not_found)
 
   attr_accessor :what_wrong, :what_doing, :url, :user_agent, :javascript_enabled, :referrer, :source, :page_owner
 

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -7,9 +7,8 @@ describe ReportAProblemTicket do
 
   it "should add a tag identifying the whitelisted source" do
     ticket.tags.should eq(['report_a_problem'])
-    ticket(source: 'government').tags.should eq(['report_a_problem', 'government'])
-    ticket(source: 'citizen').tags.should eq(['report_a_problem', 'citizen'])
-    ticket(source: 'specialist').tags.should eq(['report_a_problem', 'specialist'])
+    ticket(source: 'inside_government').tags.should eq(['report_a_problem', 'inside_government'])
+    ticket(source: 'mainstream').tags.should eq(['report_a_problem', 'mainstream'])
     ticket(source: 'page_not_found').tags.should eq(['report_a_problem', 'page_not_found'])
     ticket(source: 'random').tags.should eq(['report_a_problem'])
   end
@@ -17,7 +16,7 @@ describe ReportAProblemTicket do
   it "should add a tag identifying the page owner" do
     ticket(page_owner: 'hmrc').tags.should eq(['report_a_problem', 'page_owner/hmrc'])
     ticket(page_owner: 'number_10').tags.should eq(['report_a_problem', 'page_owner/number_10'])
-    ticket(page_owner: 'home_office', source: 'government').tags.should eq(['report_a_problem', 'government', 'page_owner/home_office'])
+    ticket(page_owner: 'home_office', source: 'inside_government').tags.should eq(['report_a_problem', 'inside_government', 'page_owner/home_office'])
   end
 
   it "ignores the page owner if it contains any non-alphanumeric characters, other than underscore" do


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/47732031

Report a problem now recognises `:source` and `:page_owner`, and converts them to appropriate tags sent with the Zendesk ticket. `:source` must be one of the whitelisted values for it to be recognised (currently just `"citizen"`, `"government"` or `"specialist"`), and `:page_owner` can be an alphanumeric string with underscores.

Related changes to static and slimmer: https://github.com/alphagov/static/pull/266 https://github.com/alphagov/slimmer/pull/45
