### PR TITLE
Bump toolkit to 3.32.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ group :assets do
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   # gem 'therubyracer', :platforms => :ruby
   gem 'uglifier', '>= 1.0.3'
-  gem 'govuk_frontend_toolkit', '0.6.2'
+  gem 'govuk_frontend_toolkit', '0.32.2'
   gem 'sass', '3.2.1'
   gem 'sass-rails', "  ~> 3.2.3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,7 +62,7 @@ GEM
     faye-websocket (0.4.6)
       eventmachine (>= 0.12.0)
     ffi (1.1.5)
-    govuk_frontend_toolkit (0.6.2)
+    govuk_frontend_toolkit (0.32.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hashie (2.0.5)
@@ -205,7 +205,7 @@ DEPENDENCIES
   aws-ses
   capybara (= 1.1.2)
   exception_notification (= 3.0.1)
-  govuk_frontend_toolkit (= 0.6.2)
+  govuk_frontend_toolkit (= 0.32.2)
   plek (= 1.1.0)
   poltergeist (= 0.7.0)
   rails (= 3.2.13)


### PR DESCRIPTION
Continuation of this work: https://github.com/alphagov/static/pull/270

Associated with (though they don't need to be merged simultaneously):

https://github.com/alphagov/business-support-finder/pull/31
https://github.com/alphagov/calendars/pull/37
https://github.com/alphagov/design-principles/pull/47
https://github.com/alphagov/licence-finder/pull/36
https://github.com/alphagov/smart-answers/pull/466
https://github.com/alphagov/trade-tariff-frontend/pull/80
https://github.com/alphagov/transaction-wrappers/pull/28
