### PR TITLE
bump the safe_yaml gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    safe_yaml (0.9.4)
+    safe_yaml (0.9.5)
     sass (3.2.1)
     sass-rails (3.2.5)
       railties (~> 3.2.0)


### PR DESCRIPTION
`safe_yaml` version 0.9.4 is the [cause of a travis failure](https://travis-ci.org/alphagov/feedback/builds/9935706), and googling seems to point to [incorrect file perms in the gem as the culprit](https://github.com/dtao/safe_yaml/issues/43). This issue is fixed in `safe_yaml` v0.9.5
