### PR TITLE
Disable Travis email notifications.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ rvm:
 branches:
   except:
     - release
+notifications:
+  email: false


### PR DESCRIPTION
They're unnecessary as we already get notification via the pull-requests in github.
