### PR TITLE
Invalidate trailing dot in contact email

### DIFF
--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -17,6 +17,7 @@ class ContactTicket < Ticket
   validates_length_of :name, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The name field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
   validates :email, email: { message: "The email address must be valid" }, allow_blank: true
   validates_length_of :email, :maximum => FIELD_MAXIMUM_CHARACTER_COUNT, :message => "The email field can be max #{FIELD_MAXIMUM_CHARACTER_COUNT} characters"
+  validate :invalidate_trailing_dot_in_email
   validate :validate_mail_name_connection
   validates :query, inclusion: { in: REASON_HASH.keys, message: "Please pick a valid reason for contacting us" }
   validates_presence_of :location, message: "Please tell us what your contact is to do with"
@@ -74,6 +75,12 @@ class ContactTicket < Ticket
     end
     if email.blank? and not name.blank?
       @errors.add :email, 'The email field cannot be empty'
+    end
+  end
+
+  def invalidate_trailing_dot_in_email
+    if not email.nil? and email.end_with?(".")
+      @errors.add :email, "The email address must not have a trailing full stop"
     end
   end
 

--- a/spec/models/contact_ticket_spec.rb
+++ b/spec/models/contact_ticket_spec.rb
@@ -51,6 +51,10 @@ describe ContactTicket do
     named_ticket_with(email: "abc @d.com").should have(1).error_on(:email)
   end
 
+  it "should not be valid if the email has a dot at the end" do
+    named_ticket_with(email: "abc@d.com.").should have(1).error_on(:email)
+  end
+
   it "should return contact error with too long email" do
     named_ticket_with(email: (build_random_string 1251) + "@a.com").should have(1).error_on(:email)
   end


### PR DESCRIPTION
Zendesk validation rejects tickets with a trailing dot, and the `valid_email` gem isn't marking it as invalid.
