### PR TITLE
JSON logs in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "zendesk_api", "0.4.0.rc1"
 gem "valid_email", "0.0.4"
 
 gem "statsd-ruby", "1.2.1", require: "statsd"
+gem "logstasher", "0.2.5"
 
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     json (1.8.0)
     kgio (2.7.4)
     link_header (0.0.7)
+    logstash-event (1.1.5)
+    logstasher (0.2.5)
+      logstash-event
     lrucache (0.1.4)
       PriorityQueue (~> 0.1.2)
     mail (2.5.4)
@@ -202,6 +205,7 @@ DEPENDENCIES
   exception_notification (= 4.0.0)
   gds-api-adapters (= 7.3.0)
   govuk_frontend_toolkit (= 0.32.2)
+  logstasher (= 0.2.5)
   plek (= 1.4.0)
   poltergeist (= 1.3.0)
   rails (= 3.2.14)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,4 +62,7 @@ Feedback::Application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
+  config.logstasher.enabled = true
+  config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
+  config.logstasher.supress_app_log = true
 end

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -1,0 +1,8 @@
+if Object.const_defined?('LogStasher') && LogStasher.enabled
+  LogStasher.add_custom_fields do |fields|
+    # Mirrors Nginx request logging, e.g GET /path/here HTTP/1.1
+    fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
+    # Pass X-Varnish to logging
+    fields[:varnish_id] = request.headers['X-Varnish']
+  end
+end


### PR DESCRIPTION
This change introduces the 'logstasher' gem to make the production
logs be in JSON format, so that it's easier for kibana to parse
