### PR TITLE
Move report a problem to "support"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "logstasher", "0.2.5"
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem "gds-api-adapters", "7.3.0"
+  gem "gds-api-adapters", "7.4.0"
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,7 +60,7 @@ GEM
       faraday (>= 0.7.4, < 0.9)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    gds-api-adapters (7.3.0)
+    gds-api-adapters (7.4.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -203,7 +203,7 @@ DEPENDENCIES
   aws-ses
   capybara (= 2.1.0)
   exception_notification (= 4.0.0)
-  gds-api-adapters (= 7.3.0)
+  gds-api-adapters (= 7.4.0)
   govuk_frontend_toolkit (= 0.32.2)
   logstasher (= 0.2.5)
   plek (= 1.4.0)


### PR DESCRIPTION
After this change, the `feedback` app does basic validation on
problem reports, and then POSTs the data to the 'support' app,
instead of Zendesk.
