### PR TITLE
Handle invalid form params

### DIFF
--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -32,11 +32,11 @@ class FeedbackController < ApplicationController
   end
 
   def contact_submit
-    submit sanitised(params[:contact].merge(technical_attributes)), :contact
+    submit sanitised((params[:contact] || {}).merge(technical_attributes)), :contact
   end
 
   def foi_submit
-    submit sanitised(params[:foi].merge(technical_attributes)), :foi
+    submit sanitised((params[:foi] || {}).merge(technical_attributes)), :foi
   end
 
   def report_a_problem_submit

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -77,6 +77,12 @@ describe "Contact" do
                                :description => expected_description
   end
 
+  it "should still work even if the request doesn't have correct form params" do
+    post "/feedback/contact", {}
+
+    response.body.should include("Please check the form")
+  end
+
   it "should not proceed if the user hasn't filled in all required fields" do
     visit "/feedback/contact"
 

--- a/spec/requests/foi_spec.rb
+++ b/spec/requests/foi_spec.rb
@@ -51,6 +51,12 @@ describe "FOI" do
     i_should_be_on "/feedback/foi"
   end
 
+  it "should still work even if the request doesn't have correct form params" do
+    post "/feedback/foi", {}
+
+    response.body.should include("Please check the form")
+  end
+
   it "should not accept spam (ie requests with val field filled in)" do
     visit "/feedback/foi"
 

--- a/spec/requests/report_a_problem_spec.rb
+++ b/spec/requests/report_a_problem_spec.rb
@@ -81,6 +81,12 @@ describe "Reporting a problem with this content/tool" do
     end
   end
 
+  it "should still work even if the request doesn't have correct form params" do
+    post "/feedback", {}
+
+    response.body.should include("we're unable to send your message")
+  end
+
   it "should handle errors when submitting problem reports" do
     support_isnt_available
 


### PR DESCRIPTION
some older mobiles don't seem to send the correct form params upon
report-a-problem submissions, which caused an exception before this fix.
