### PR TITLE
remove unnecessary sectional context

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -46,11 +46,6 @@ GOVUK.feedback.initCounters = function () {
 }
 
 GOVUK.feedback.checkRadio = function () {
-    if ($('#location-section').is(':checked')) {
-        $('#contact_section').removeAttr('disabled');
-    } else {
-        $('#contact_section').attr('disabled', 'disabled')
-    }
     if ($('#location-specific').is(':checked')) {
         $('#link').removeAttr('disabled');
     } else {
@@ -60,11 +55,6 @@ GOVUK.feedback.checkRadio = function () {
 
 GOVUK.feedback.prepopulateFormBasedOnReferrer = function () {
     $('#link').val(document.referrer);
-    // special handling for the service manual as it's not strictly a section on GOV.UK
-    if (document.referrer.indexOf("service-manual") >= 0) {
-        $('#location-section').click();
-        $('#contact_section').val("dbdss");
-    }
 }
 
 GOVUK.feedback.init = function () {

--- a/app/controllers/feedback_controller.rb
+++ b/app/controllers/feedback_controller.rb
@@ -16,11 +16,6 @@ class FeedbackController < ApplicationController
     :contact
   ]
 
-  before_filter :get_sections, :only => [
-    :contact,
-    :contact_submit
-  ]
-
   before_filter :setup_slimmer_artefact
 
   def contact
@@ -125,10 +120,6 @@ class FeedbackController < ApplicationController
         end
       end
     end
-  end
-
-  def get_sections
-    @sections = ticket_client.get_sections
   end
 
   def ticket_client

--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -1,6 +1,6 @@
 class ContactTicket < Ticket
   attr_accessor :location, :link, :textdetails,
-                :section, :name, :email,
+                :name, :email,
                 :javascript_enabled, :referrer
 
   validate :validate_link
@@ -53,7 +53,6 @@ class ContactTicket < Ticket
       tags: [],
       name: name,
       email: email,
-      section: section,
       description: contact_ticket_description
     }
   end

--- a/app/views/feedback/contact.html.erb
+++ b/app/views/feedback/contact.html.erb
@@ -18,16 +18,6 @@
     </label>
   </p>
 
-  <p class="inline option group">
-    <label>
-      <input type="radio" name="contact[location]" id="location-section" value="section"
-        <%= @old ? (@old[:location] == "section" ? "checked" : "" ) : "" %> > A specific section
-    </label>
-    <label for="contact_section" class="visuallyhidden">Section</label>
-    <%= select_tag "contact[section]", options_for_select(@sections, (@old ? @old[:section] : '')) %>
-  </p>
-
-
   <% if @errors && @errors[:link] %>
     <p class="validation group">
     <span class="validation-message" id="linkerror"><%= @errors[:link].first %></span>

--- a/lib/ticket_client.rb
+++ b/lib/ticket_client.rb
@@ -2,8 +2,6 @@ require 'zendesk_didnt_create_ticket_error'
 require 'zendesk_config'
 
 class TicketClient
-  SECTION_FIELD = 21649362
-
   class << self
     def raise_ticket(zendesk)
       tags = zendesk[:tags] << "public_form"
@@ -12,25 +10,11 @@ class TicketClient
         subject: zendesk[:subject],
         tags: tags,
         requester: {name: zendesk[:name], email: email},
-        fields: [{id: SECTION_FIELD, value: zendesk[:section]}],
         description: zendesk[:description]
       }
       unless client.tickets.create!(ticket_details)
         raise ZendeskDidntCreateTicketError, "Failed to create Zendesk ticket: #{ticket_details.inspect}"
       end
-    end
-
-    def get_sections
-      sections_hash = {}
-      unless client.nil?
-        section_field = client.ticket_fields.find(:id => SECTION_FIELD)
-        unless section_field.nil?
-          section_field.custom_field_options.each do |tf|
-            sections_hash[tf.name] = tf.value
-          end
-        end
-      end
-      sections_hash
     end
 
     def client

--- a/lib/ticket_client_dummy.rb
+++ b/lib/ticket_client_dummy.rb
@@ -15,13 +15,5 @@ class TicketClientDummy
         zendesk
       end
     end
-
-    def get_sections
-      Rails.logger.info 'Zendesk get sections'
-      {
-        'Test Section One' => 'test_section_one',
-        'Test Section Two' => 'test_section_two'
-      }
-    end
   end
 end

--- a/spec/lib/ticket_client_dummy_spec.rb
+++ b/spec/lib/ticket_client_dummy_spec.rb
@@ -31,10 +31,4 @@ describe TicketClientDummy do
       with("Zendesk ticket creation fail for: #{details}")
     expect {@client.raise_ticket(details)}.to raise_error("Failed to create Zendesk ticket")
   end
-
-  it 'should simulate returning available departments' do
-    Rails.logger.should_receive(:info).
-      with('Zendesk get sections')
-    @client.get_sections.should_not be_empty
-  end
 end

--- a/spec/support/zendesk_stubs.rb
+++ b/spec/support/zendesk_stubs.rb
@@ -7,10 +7,6 @@ module ZendeskStubs
 
     attr_accessor :tickets, :fail
 
-    def get_sections
-      {"Test Section" =>"test_section"}
-    end
-
     def raise_ticket(params)
       if @fail
         @tickets << params


### PR DESCRIPTION
Before this change, the named contact form allowed the user to select
sections of the site as an answer to "what's it about". While this info was
being captured, it wasn't being used for anything except routing tickets about the
Service Manual to the appropriate Zendesk group. Furthermore, the section list is configured in Zendesk and not taken from the live site, and the list hasn't been maintained.

The change removes the section option; routing of Service Manual tickets
will be done on the basis of the referrering page matching /service-manual/.

Before:

![image](https://f.cloud.github.com/assets/23801/1200136/dadbf28c-251f-11e3-9991-16875ab278f2.png)

After:

![image](https://f.cloud.github.com/assets/23801/1200134/c915acdc-251f-11e3-83a3-74ae72ccf099.png)
