### PR TITLE
bugfix: page titles

### DIFF
--- a/app/views/contact/foi/new.html.erb
+++ b/app/views/contact/foi/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= @page_title %><% end %>
+<% content_for :title do "Make a Freedom of Information request" end %>
 
  <header class="page-header group">
     <div class="full-width">

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= @page_title %><% end %>
+<% content_for :title do "Contact GOV.UK" end %>
 
   <header class="page-header group">
     <div class="full-width">

--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :title do %><%= @page_title %><% end %>
+<% content_for :title do "Contact" end %>
 
   <header class="page-header group">
     <div class="full-width">

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -13,6 +13,11 @@ def contact_submission_should_be_successful
 end
 
 describe "Contact" do
+  it "should display an index page" do
+    visit "/contact"
+    expect(page).to have_title "Contact"
+  end
+
   include GdsApi::TestHelpers::Support
   it "should let the user submit a request with contact details" do
     stub_post = stub_support_named_contact_creation(
@@ -25,6 +30,7 @@ describe "Contact" do
     )
 
     visit "/contact/govuk"
+    expect(page).to have_title "Contact GOV.UK"
 
     choose "location-all"
     fill_in_valid_contact_details_and_description

--- a/spec/requests/foi_spec.rb
+++ b/spec/requests/foi_spec.rb
@@ -14,6 +14,7 @@ describe "FOI" do
     stub_post = stub_support_foi_request_creation(requester: {name: "test name", email: "a@a.com"}, details: "test foi request")
 
     visit "/contact/foi"
+    expect(page).to have_title "Make a Freedom of Information request"
 
     fill_in "Your name", :with => "test name"
     fill_in "Your email address", :with => "a@a.com"


### PR DESCRIPTION
the recent styling change broke page titles. This change fixes the titles
and adds some specs to prevent breakage in the future.
