### PR TITLE
update language on contact index page

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -29,9 +29,9 @@
         <p>Ask for information held on topics related to Cabinet Office or the Government Digital Service, or find out if it is already available.</p>
       </li>
       <li class="contact-keyline">
-        <p><a href="/contact/govuk">Use this form</a> to ask questions or make comments about the GOV.UK website.</p>
+        <p>Use the <a href="/contact/govuk">GOV.UK form</a> to send your questions or comments about the website.</p>
         <br/>
-        <p>You can also try the <a href="/help">help pages</a> to find answers to the most common questions about GOV.UK.</p>
+        <p>Check the <a href="/help">GOV.UK help pages</a> for answers to the most common questions about the website.</p>
       </li>
     </ul>
  </div>


### PR DESCRIPTION
![image](https://f.cloud.github.com/assets/23801/1466284/e224c220-456e-11e3-8ded-fef7c5fe37e5.png)

this change:
- simplifies the first sentence
- moves the link to the help pages to the bottom, because data shows that few people
  click on
- brings the description of the GOV.UK contact form closer in line with the User Support
  team's actual remit
