### PR TITLE
fix typo: JobCentre => Jobcentre

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -21,7 +21,7 @@
         <p>Get help with student loan applications and grants.</p>
       </li>
       <li>
-        <h2><a href="/contact/jobcentre-plus">JobCentre Plus</a></h2>
+        <h2><a href="/contact/jobcentre-plus">Jobcentre Plus</a></h2>
         <p>Get advice on benefits such as Jobseeker's Allowance (JSA).</p>
       </li>
       <li>


### PR DESCRIPTION
Then it's consistent with https://www.gov.uk/contact-jobcentre-plus:

![image](https://f.cloud.github.com/assets/23801/1466330/53324b68-456f-11e3-9912-7a0d9a55ef04.png)
