### PR TITLE
remove FOI request link from index page

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -24,10 +24,6 @@
         <h2><a href="/contact/jobcentre-plus">Jobcentre Plus</a></h2>
         <p>Get advice on benefits such as Jobseeker's Allowance (JSA).</p>
       </li>
-      <li>
-        <h2><a href="/contact/foi">Make a Freedom of Information request</a></h2>
-        <p>Ask for information held on topics related to Cabinet Office or the Government Digital Service, or find out if it is already available.</p>
-      </li>
       <li class="contact-keyline">
         <p>Use the <a href="/contact/govuk">GOV.UK form</a> to send your questions or comments about the website.</p>
         <br/>


### PR DESCRIPTION
since the renaming of 'feedback' to 'contact' in the footer and the
introduction of the contact index page, many users are submitting FOI
requests that aren't legitimate FOI requests, and should really be
coming through the contact form instead.

The FOI request form is still accessible through the /help pages.
