### PR TITLE
remove redirects for internal GOV.UK contact links

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -5,7 +5,7 @@
     <p>Try one of the popular topics below to get a faster answer.</p>
     <ul class="categories group">
       <li>
-        <h2><a href="/contact/dvla">Driving licences and car tax</a></h2>
+        <h2><a href="/contact-the-dvla">Driving licences and car tax</a></h2>
         <p>Contact DVLA for questions about driving and your vehicle.</p>
       </li>
       <li>
@@ -13,15 +13,15 @@
         <p>Use Universal Jobmatch to find jobs and retrieve your lost login details.</p>
       </li>
       <li>
-        <h2><a href="/contact/passport-advice-line">Passport Advice Line</a></h2>
+        <h2><a href="/passport-advice-line">Passport Advice Line</a></h2>
         <p>Get help with your passport application and renewals if you're a British Citizen.</p>
       </li>
       <li>
-        <h2><a href="/contact/student-finance-england">Student Finance England</a></h2>
+        <h2><a href="/contact-student-finance-england">Student Finance England</a></h2>
         <p>Get help with student loan applications and grants.</p>
       </li>
       <li>
-        <h2><a href="/contact/jobcentre-plus">Jobcentre Plus</a></h2>
+        <h2><a href="/contact-jobcentre-plus">Jobcentre Plus</a></h2>
         <p>Get advice on benefits such as Jobseeker's Allowance (JSA).</p>
       </li>
       <li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,10 @@ Feedback::Application.routes.draw do
       post 'problem_reports', to: "problem_reports#create", format: false
     end
 
-    get 'dvla', to: redirect("/contact-the-dvla")
     get 'look-for-jobs', to: redirect("https://jobsearch.direct.gov.uk/ContactUs.aspx")
+
+    # these routes are deprecated and can be deleted as soon as the /contact page cache expires
+    get 'dvla', to: redirect("/contact-the-dvla")
     get 'passport-advice-line', to: redirect("/passport-advice-line")
     get 'student-finance-england', to: redirect("/contact-student-finance-england")
     get 'jobcentre-plus', to: redirect("/contact-jobcentre-plus")


### PR DESCRIPTION
the original intent was to track all contact links consistently using
redirects, but since all but one are internal GOV.UK links, it's easier to measure
those redirects using google analytics and the remaining one from CDN logs.
