### PR TITLE
more accurate description of the help pages

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -27,7 +27,7 @@
       <li class="contact-keyline">
         <p>Use the <a href="/contact/govuk">GOV.UK form</a> to send your questions or comments about the website.</p>
         <br/>
-        <p>Check the <a href="/help">GOV.UK help pages</a> for answers to the most common questions about the website.</p>
+        <p>Check the <a href="/help">GOV.UK help pages</a> to find out about the use of cookies, accessibility of the site, the privacy policy and terms and conditions of use.</p>
       </li>
     </ul>
  </div>


### PR DESCRIPTION
currently, the description of the help pages promises more than the /help
pages deliver. Analytics show that almost as many users click through to the
/help pages as go to the contact form.

This updates the description on the link to reflect
the actual content on that page. The copy itself closely follows the explanation
on the /help page.
