### PR TITLE
move legacy redirects out of routes.rb into the router

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,21 +14,7 @@ Feedback::Application.routes.draw do
     end
 
     get 'look-for-jobs', to: redirect("https://jobsearch.direct.gov.uk/ContactUs.aspx")
-
-    # these routes are deprecated and can be deleted as soon as the /contact page cache expires
-    get 'dvla', to: redirect("/contact-the-dvla")
-    get 'passport-advice-line', to: redirect("/passport-advice-line")
-    get 'student-finance-england', to: redirect("/contact-student-finance-england")
-    get 'jobcentre-plus', to: redirect("/contact-jobcentre-plus")
   end
-
-  # these are deprecated routes that can be removed once all frontends are submitting to the /contact endpoints
-  get "/feedback", :to => redirect("/contact"), :format => false
-  post "/feedback", :to => "contact/govuk/problem_reports#create", :format => false
-  get "/feedback/contact", :to => redirect("/contact/govuk"), :format => false
-  post "/feedback/contact", :to => "contact/govuk#create", :format => false
-  get "/feedback/foi", :to => redirect("/contact/foi"), :format => false
-  post "/feedback/foi", :to => "contact/foi#create", :format => false
 
   root :to => redirect("/contact")
 

--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -18,6 +18,19 @@ namespace :router do
     ].each do |path, type|
       @router_api.add_route(path, type, @app_id, :skip_commit => true)
     end
+
+    [
+      %w(/feedback /contact),
+      %w(/feedback/contact /contact/govuk),
+      %w(/feedback/foi /contact/foi),
+      %w(/contact/dvla /contact-the-dvla),
+      %w(/contact/passport-advice-line /passport-advice-line),
+      %w(/contact/student-finance-england /contact-student-finance-england),
+      %w(/contact/jobcentre-plus /contact-jobcentre-plus),
+    ].each do |from, to|
+      @router_api.add_redirect_route(from, "exact", to, "permanent", :skip_commit => true)
+    end
+
     @router_api.commit_routes
   end
 

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -39,24 +39,6 @@ describe "Contact" do
     assert_requested(stub_post)
   end
 
-  # this can be deleted when the deprecated routes are dropped
-  it "should let the user submit a request on the legacy endpoint" do
-    stub_post = stub_support_named_contact_creation
-
-    post "/feedback/contact", {
-      contact: {
-        name: "test name",
-        email: "test@test.com",
-        textdetails: "some text",
-        query: "cant-find",
-        location: "all"
-      }
-    }
-
-    expect(response.status).to eq(200)
-    assert_requested(stub_post)
-  end
-
   it "should not accept spam (ie a request with val field filled in)" do
     visit "/contact/govuk"
 

--- a/spec/requests/foi_spec.rb
+++ b/spec/requests/foi_spec.rb
@@ -28,17 +28,6 @@ describe "FOI" do
     assert_requested(stub_post)
   end
 
-  # this can be deleted when the deprecated routes are dropped
-  it "should allow submission on the legacy end-point" do
-    stub_support_foi_request_creation
-    valid_params = { foi: { name: "A", email: "a@b.com", email_confirmation: "a@b.com", textdetails: "abc" } }
-
-    # Using Rack::Test instead of capybara to allow setting headers.
-    post "/feedback/foi", valid_params
-
-    assert_requested(:post, %r{/foi_requests})
-  end
-
   it "should pass the varnish ID through to the support app if set" do
     stub_support_foi_request_creation
     valid_params = { foi: { name: "A", email: "a@b.com", email_confirmation: "a@b.com", textdetails: "abc" } }

--- a/spec/requests/report_a_problem_spec.rb
+++ b/spec/requests/report_a_problem_spec.rb
@@ -51,24 +51,6 @@ describe "Reporting a problem with this content/tool" do
     end
   end
 
-  # this can be deleted when the deprecated routes are dropped
-  it "should support ajax submission on the deprecated endpoint", :js => true do
-    stub_post = stub_support_problem_report_creation
-
-    xhr :post, "/feedback", {
-      :url => "http://www.example.com/somewhere",
-      :what_doing => "Nothing",
-      :what_wrong => "Something",
-    }
-
-    expect(response.body).to include("Thank you for your help.")
-
-    assert_requested(:post, %r{/problem_reports}) do |request|
-      response = JSON.parse(request.body)["problem_report"]
-      response["what_doing"] == "Nothing" && response["what_wrong"] == "Something"
-    end
-  end
-
   def valid_params
     {
       :url => "http://www.example.com/test_forms/report_a_problem",


### PR DESCRIPTION
this change also drops the old POST endpoints, but kibana shows that there
isn't any traffic coming into those endpoints any more.

/cc @alext
