### PR TITLE
Adopt post-redirect-get for service feedback

### DIFF
--- a/app/controllers/contact/govuk/service_feedback_controller.rb
+++ b/app/controllers/contact/govuk/service_feedback_controller.rb
@@ -11,11 +11,10 @@ class Contact::Govuk::ServiceFeedbackController < ContactController
   end
 
   def confirm_submission
-    respond_to do |format|
-      format.html do
-        render "thankyou"
-      end
-    end
+    redirect_to action: :thankyou
+  end
+
+  def thankyou
   end
 
   def respond_to_invalid_submission(ticket)

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -49,7 +49,7 @@ class ContactController < ApplicationController
   end
 
   def respond_to_invalid_submission(ticket)
-    rerender_form    
+    rerender_form
   end
 
   def confirm_submission

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Feedback::Application.routes.draw do
     namespace :govuk do
       post 'problem_reports', to: "problem_reports#create", format: false
       post 'service-feedback', to: "service_feedback#create", format: false
+      get 'thankyou', to: "service_feedback#thankyou", format: false
     end
 
     get 'look-for-jobs', to: redirect("https://jobsearch.direct.gov.uk/ContactUs.aspx")

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -14,6 +14,9 @@ describe "Service feedback submission" do
 
     submit_service_feedback
 
+    expect(response).to redirect_to(contact_govuk_thankyou_path)
+    get contact_govuk_thankyou_path
+
     expect(response.body).to include("Thank you for your feedback.")
     assert_requested(stub_post)
   end
@@ -41,6 +44,9 @@ describe "Service feedback submission" do
   it "should accept invalid submissions, just not do anything with them (because the form itself lives
     in the feedback app and re-rendering it with the user's original feedback isn't straightforward" do
     post "/contact/govuk/service-feedback", {}
+
+    expect(response).to redirect_to(contact_govuk_thankyou_path)
+    get contact_govuk_thankyou_path
 
     response.body.should include("Thank you for your feedback.")
   end


### PR DESCRIPTION
In order to prevent users from accidentally resubmitting service feedback
by hitting refresh, we redirect them to a thank you page.
