### PR TITLE
Support relative urls coming from service feedback

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 class Ticket
   include ActiveModel::Validations
   attr_accessor :val, :user_agent, :varnish_id
@@ -33,10 +35,14 @@ class Ticket
 
   def valid_url?(candidate)
     url = URI.parse(candidate) rescue false
-    url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS)
+    url.kind_of?(URI::Generic) && (url.kind_of?(URI::HTTP) || url.kind_of?(URI::HTTPS) || url.relative?)
   end
 
   def url_if_valid(candidate)
-    valid_url?(candidate) ? candidate : nil
+    case
+    when !valid_url?(candidate) then nil
+    when URI.parse(candidate).relative? then Plek.new.website_root + candidate
+    else candidate
+    end
   end
 end

--- a/spec/models/service_feedback_spec.rb
+++ b/spec/models/service_feedback_spec.rb
@@ -28,10 +28,17 @@ describe ServiceFeedback do
   it { should ensure_length_of(:url).is_at_most(2048) }
   it { should allow_value("https://www.gov.uk/done/whatever").for(:url) }
 
-  context "when a valid URL is passed" do
-    let(:subject) { ServiceFeedback.new(options) }
-    let(:options) { { service_satisfaction_rating: "5", url: "https://www.gov.uk/done/whenever" } }
-
+  context "when a valid absolute URL is passed" do
+    let(:subject) { ServiceFeedback.new(service_satisfaction_rating: "5", url: "https://www.gov.uk/done/whenever") }
     its(:details) { should include(url: "https://www.gov.uk/done/whenever") }
+  end
+
+  context "when a relative URL is passed (in prod)" do
+    before do
+      Plek.any_instance.stub(:website_root).and_return("https://www.something.gov.uk")
+    end
+
+    let(:subject) { ServiceFeedback.new(service_satisfaction_rating: "5", url: "/done/whenever") }
+    its(:details) { should include(url: "https://www.something.gov.uk/done/whenever") }
   end
 end


### PR DESCRIPTION
On preview/stg/prod, the URLs coming with service feedback are relative
(not absolute) URLs. This change allows these URLs to be passed through to
support.
