### PR TITLE
Bugfix: correct referrer for report-a-problem

### DIFF
--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -32,6 +32,10 @@ class ReportAProblemTicket < Ticket
     url_if_valid(@url)
   end
 
+  def referrer=(new_referrer)
+    @referrer = (new_referrer == 'unknown' ? nil : new_referrer)
+  end
+
   def referrer
     url_if_valid(@referrer)
   end

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -55,5 +55,9 @@ describe ReportAProblemTicket do
     ticket(referrer: "https://www.gov.uk").referrer.should eq('https://www.gov.uk')
     ticket(referrer: "http://bla.example.org:9292/méh/fào?bar").referrer.should be_nil
     ticket(referrer: nil).referrer.should be_nil
-  end  
+  end
+
+  it "should treat a 'unknown' referrer as nil" do
+    expect(ticket(referrer: "unknown").referrer).to be_nil
+  end
 end


### PR DESCRIPTION
For problem reports with an unknown referrer submitted via AJAX,
[the 'referrer' param is set to 'unknown'](https://github.com/alphagov/static/blob/master/app/assets/javascripts/report-a-problem.js#L64). This case was broken
by the changes introduced by https://github.com/alphagov/feedback/pull/109.
