### PR TITLE
Bump govuk_frontend_toolkit, remove gemfury as gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :assets do
   # See https://github.com/sstephenson/execjs#readme for more supported runtimes
   # gem 'therubyracer', :platforms => :ruby
   gem 'uglifier', '2.1.2'
-  gem 'govuk_frontend_toolkit', '0.41.0'
+  gem 'govuk_frontend_toolkit', '0.43.2'
   gem 'sass', '3.2.1'
   gem 'sass-rails', "  ~> 3.2.3"
   gem 'jquery-rails', '2.1.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (0.41.0)
+    govuk_frontend_toolkit (0.43.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.3)
@@ -91,7 +91,7 @@ GEM
       capybara (~> 2.1.0)
       faye-websocket (>= 0.4.4, < 0.5.0)
       http_parser.rb (~> 0.5.3)
-    polyglot (0.3.3)
+    polyglot (0.3.4)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -191,7 +191,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification (= 4.0.0)
   gds-api-adapters (= 8.2.1)
-  govuk_frontend_toolkit (= 0.41.0)
+  govuk_frontend_toolkit (= 0.43.2)
   jquery-rails (= 2.1.2)
   logstasher (= 0.4.1)
   plek (= 1.5.0)


### PR DESCRIPTION
It's no longer necessary - every gem is on rubygems
