### PR TITLE
Don't manually pass through X-Varnish

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -86,6 +86,6 @@ class ContactController < ApplicationController
   end
 
   def technical_attributes
-    { user_agent: request.user_agent, varnish_id: request.env["HTTP_X_VARNISH"] }
+    { user_agent: request.user_agent }
   end
 end

--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -28,9 +28,9 @@ class ContactTicket < Ticket
     if valid?      
       support_api = GdsApi::Support.new(SUPPORT_API[:url], bearer_token: SUPPORT_API[:bearer_token])
       if anonymous?
-        support_api.create_anonymous_long_form_contact(ticket_details, headers: { "X-Varnish" => varnish_id })
+        support_api.create_anonymous_long_form_contact(ticket_details)
       else
-        support_api.create_named_contact(ticket_details, headers: { "X-Varnish" => varnish_id })
+        support_api.create_named_contact(ticket_details)
       end
     end
   end

--- a/app/models/foi_ticket.rb
+++ b/app/models/foi_ticket.rb
@@ -14,7 +14,7 @@ class FoiTicket < Ticket
   def save
     if valid?
       support_api = GdsApi::Support.new(SUPPORT_API[:url], bearer_token: SUPPORT_API[:bearer_token])
-      support_api.create_foi_request(ticket_details, headers: { "X-Varnish" => varnish_id })
+      support_api.create_foi_request(ticket_details)
     end
   end
 

--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -12,7 +12,7 @@ class ReportAProblemTicket < Ticket
   def save
     if valid?
       support_api = GdsApi::Support.new(SUPPORT_API[:url], bearer_token: SUPPORT_API[:bearer_token])
-      support_api.create_problem_report(ticket_details, headers: { "X-Varnish" => varnish_id })
+      support_api.create_problem_report(ticket_details)
     end
   end
 

--- a/app/models/service_feedback.rb
+++ b/app/models/service_feedback.rb
@@ -12,7 +12,7 @@ class ServiceFeedback < Ticket
   def save
     if valid?
       support_api = GdsApi::Support.new(SUPPORT_API[:url], bearer_token: SUPPORT_API[:bearer_token])
-      support_api.create_service_feedback(details, headers: { "X-Varnish" => varnish_id })
+      support_api.create_service_feedback(details)
     end
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,7 +2,7 @@ require 'uri'
 
 class Ticket
   include ActiveModel::Validations
-  attr_accessor :val, :user_agent, :varnish_id
+  attr_accessor :val, :user_agent
 
   # This is deliberately higher than the max character count
   # in the front-end (javascript and maxlength in the markup),

--- a/config/initializers/logstasher.rb
+++ b/config/initializers/logstasher.rb
@@ -4,6 +4,5 @@ if Object.const_defined?('LogStasher') && LogStasher.enabled
     fields[:request] = "#{request.request_method} #{request.fullpath} #{request.headers['SERVER_PROTOCOL']}"
     # Pass the request id to logging
     fields[:govuk_request_id] = request.headers['GOVUK-Request-Id']
-    fields[:varnish_id] = request.headers['X-Varnish']
   end
 end

--- a/spec/requests/foi_spec.rb
+++ b/spec/requests/foi_spec.rb
@@ -28,18 +28,6 @@ describe "FOI" do
     assert_requested(stub_post)
   end
 
-  it "should pass the varnish ID through to the support app if set" do
-    stub_support_foi_request_creation
-    valid_params = { foi: { name: "A", email: "a@b.com", email_confirmation: "a@b.com", textdetails: "abc" } }
-
-    # Using Rack::Test instead of capybara to allow setting headers.
-    post "/contact/foi", valid_params, {"HTTP_X_VARNISH" => "12345"}
-
-    assert_requested(:post, %r{/foi_requests}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
-  end
-
   it "recreate non-UTF-char bug" do
     stub_support_foi_request_creation
 

--- a/spec/requests/report_a_problem_spec.rb
+++ b/spec/requests/report_a_problem_spec.rb
@@ -71,17 +71,6 @@ describe "Reporting a problem with this content/tool" do
     end
   end
 
-  it "should pass the varnish ID through to the support app if set" do
-    stub_support_problem_report_creation
-
-    # Using Rack::Test instead of capybara to allow setting headers.
-    post "/contact/govuk/problem_reports", valid_params, {"HTTP_X_VARNISH" => "12345"}
-
-    assert_requested(:post, %r{/problem_reports}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
-  end
-
   it "should still work even if the request doesn't have correct form params" do
     post "/contact/govuk/problem_reports", {}
 

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -32,16 +32,6 @@ describe "Service feedback submission" do
     end
   end
 
-  it "should pass the varnish ID through to the support app if set" do
-    stub_support_service_feedback_creation
-
-    submit_service_feedback("HTTP_X_VARNISH" => "12345")
-
-    assert_requested(:post, %r{/service_feedback}) do |request|
-      request.headers["X-Varnish"] == "12345"
-    end
-  end
-
   it "should accept invalid submissions, just not do anything with them (because the form itself lives
     in the feedback app and re-rendering it with the user's original feedback isn't straightforward" do
     post "/contact/govuk/service-feedback", {}


### PR DESCRIPTION
This is no longer necessary, since gds-api-adapters already
passes the GOV.UK request id (which carries the same info)
