### PR TITLE
Configure asset host in development mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,4 +28,8 @@ Feedback::Application.configure do
 
   # Expands the lines which load the assets
   config.assets.debug = true
+
+  if ENV['GOVUK_ASSET_ROOT'].present?
+    config.asset_host = ENV['GOVUK_ASSET_ROOT']
+  end
 end


### PR DESCRIPTION
When run under `govuk_setenv`, this configures the asset host to point
at the assets-origin on the dev VM.  This will give us better dev-prod
parity, and enable running this behind the router in dev.
