### PR TITLE
Check SASS compiles as part of Jenkins test runner

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -7,3 +7,4 @@ git clean -fdx
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
 bundle exec rake
+bundle exec rake assets:precompile


### PR DESCRIPTION
Running asset precompile will catch SASS syntactic/reference errors earlier.
