### PR TITLE
Add rudimentary spam protection

### DIFF
--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -9,7 +9,7 @@ class ReportAProblemTicket < Ticket
   validates :what_doing, :presence => true, :if => proc{|ticket| ticket.what_wrong.blank? }
 
   def save
-    if valid?
+    if valid? && !spam?
       support_api = GdsApi::Support.new(SUPPORT_API[:url], bearer_token: SUPPORT_API[:bearer_token])
       support_api.create_problem_report(ticket_details)
     end
@@ -33,6 +33,10 @@ class ReportAProblemTicket < Ticket
 
   def referrer
     url_if_valid(@referrer)
+  end
+
+  def spam?
+    PROBLEM_REPORT_SPAM_MATCHERS.any? { |pattern| pattern[self] }
   end
 
   private

--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -1,0 +1,4 @@
+# WARNING: this file is replaced during deployment
+
+# this constant is a list of lambdas which detect spam problem report tickets
+PROBLEM_REPORT_SPAM_MATCHERS = []

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -50,4 +50,15 @@ describe ReportAProblemTicket do
   it "should treat a 'unknown' referrer as nil" do
     expect(ticket(referrer: "unknown").referrer).to be_nil
   end
+
+  it "should know if it's spam or not" do
+    PROBLEM_REPORT_SPAM_MATCHERS << lambda { |message| message.what_wrong.include?("spammy spam") }
+
+    expect(ticket(what_wrong: "spammy spam")).to be_spam
+    expect(ticket(what_wrong: "normal content")).to_not be_spam
+  end
+
+  after do
+    PROBLEM_REPORT_SPAM_MATCHERS.clear
+  end
 end

--- a/spec/requests/report_a_problem_spec.rb
+++ b/spec/requests/report_a_problem_spec.rb
@@ -53,6 +53,28 @@ describe "Reporting a problem with this content/tool" do
     end
   end
 
+  context "when the message follows a known spam pattern" do
+    it "confirms submission but doesn't actually persist the message" do
+      PROBLEM_REPORT_SPAM_MATCHERS << lambda do |message|
+        message.what_doing.present? && message.what_doing.include?("spammy spam")
+      end
+
+      visit "/test_forms/report_a_problem"
+
+      fill_in "What you were doing", with: "spammy spam"
+      fill_in "What went wrong", with: "Nothing"
+      click_on "Send"
+
+      page.should have_content("Thank you for your help.")
+
+      assert_not_requested(:post, %r{/problem_reports})
+    end
+
+    after do
+      PROBLEM_REPORT_SPAM_MATCHERS.clear
+    end
+  end
+
   def valid_params
     {
       :url => "http://www.example.com/test_forms/report_a_problem",


### PR DESCRIPTION
The GOV.UK feedback forms get regularly spammed with the same/similar
submissions (which are usually probing for SQL injection vulnerabilities
and the like). This mechanism allows those spam submissions to be filtered out
without notifying the spammer that they've been removed.

/cc @dsingleton 
