### PR TITLE
Restrict the length of the user agent

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -12,6 +12,7 @@ class Ticket
 
   validate :validate_val
   validates_length_of :url, maximum: 2048
+  validates_length_of :user_agent,  maximum: 2048
 
   def initialize(attributes = {})
     attributes.each do |key, value|

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -15,6 +15,10 @@ describe Ticket do
     Ticket.new(url: 'https://www.gov.uk/' + ("a" * 2048)).should have(1).error_on(:url)
   end
 
+  it "should validate the length of the user agent" do
+    Ticket.new(user_agent: 'Mozilla ' + ("a" * 2048)).should have(1).error_on(:user_agent)
+  end
+
   it "should filter 'url' to either nil or a valid URL" do
     Ticket.new(url: "https://www.gov.uk").url.should eq('https://www.gov.uk')
     Ticket.new(url: "http://bla.example.org:9292/méh/fào?bar").url.should be_nil


### PR DESCRIPTION
Because the user agent is persisted, the allowed length can't be longer than
the allowed length in the storage.

This PR should be merged close to https://github.com/alphagov/support-api/pull/7
