### PR TITLE
Remove the 'support-api' feature flag

### DIFF
--- a/app/models/service_feedback.rb
+++ b/app/models/service_feedback.rb
@@ -11,8 +11,7 @@ class ServiceFeedback < Ticket
 
   def save
     if valid?
-      api = SUPPORT_API_ENABLED ? Feedback.support_api : Feedback.support
-      api.create_service_feedback(options)
+      Feedback.support_api.create_service_feedback(options)
     end
   end
 

--- a/config/initializers/support_app.rb
+++ b/config/initializers/support_app.rb
@@ -3,5 +3,3 @@ require 'gds_api/support_api'
 
 Feedback.support = GdsApi::Support.new(Plek.current.find('support'), bearer_token: 'xxxxx')
 Feedback.support_api = GdsApi::SupportApi.new(Plek.current.find('support-api'))
-
-SUPPORT_API_ENABLED = true

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -27,32 +27,6 @@ describe "Service feedback submission" do
     assert_requested(stub_post)
   end
 
-  # this is very temporary, until the 'support-api' is running stable in prod
-  it "should pass the feedback through the support (when the feature flag is flipped)" do
-    SUPPORT_API_ENABLED = false
-
-    stub_post = stub_support_service_feedback_creation(
-      service_satisfaction_rating: 5,
-      details: "the transaction is ace",
-      slug: "some-transaction",
-      user_agent: nil,
-      javascript_enabled: false,
-      referrer: "https://www.some-transaction.service.gov/uk/completed",
-      path: "/done/some-transaction",
-      url: "https://www.gov.uk/done/some-transaction",
-    )
-
-    submit_service_feedback
-
-    expect(response).to redirect_to(contact_anonymous_feedback_thankyou_path)
-    get contact_anonymous_feedback_thankyou_path
-
-    expect(response.body).to include("Thank you for your feedback.")
-    assert_requested(stub_post)
-
-    SUPPORT_API_ENABLED = true
-  end
-
   it "should include the user_agent if available" do
     stub_support_api_service_feedback_creation
 


### PR DESCRIPTION
The `support-api` is humming along nicely on production, so it's no longer
necessary to keep the feature flag for switching between the two apps.
