### PR TITLE
Post long-form contacts to `support-api`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem 'rack_strip_client_ip', '0.0.1'
 if ENV['API_DEV']
   gem "gds-api-adapters", :path => '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '11.5.0'
+  gem 'gds-api-adapters', '14.7.0'
 end
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,11 +50,12 @@ GEM
       multi_json (~> 1.0)
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
-    gds-api-adapters (11.5.0)
+    gds-api-adapters (14.7.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek
+      rack-cache
       rest-client (~> 1.6.3)
     govuk_frontend_toolkit (1.6.0)
       rails (>= 3.1.0)
@@ -180,7 +181,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (= 3.1.15)
   capybara (= 2.1.0)
-  gds-api-adapters (= 11.5.0)
+  gds-api-adapters (= 14.7.0)
   govuk_frontend_toolkit (= 1.6.0)
   logstasher (= 0.4.8)
   plek (= 1.5.0)

--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -27,7 +27,7 @@ class ContactTicket < Ticket
   def save
     if valid?
       if anonymous?
-        Feedback.support.create_anonymous_long_form_contact(ticket_details)
+        Feedback.support_api.create_anonymous_long_form_contact(ticket_details)
       else
         Feedback.support.create_named_contact(ticket_details)
       end
@@ -38,11 +38,13 @@ class ContactTicket < Ticket
   def ticket_details
     details = {
       details: textdetails,
-      link: link,
+      link: link, # needed for the `support` app
+      user_specified_url: link, # needed for the `support-api` app
       user_agent: user_agent,
       referrer: referrer,
       javascript_enabled: javascript_enabled,
       url: url,
+      path: url ? URI(url).path : nil, # needed for the `support-api` app
     }
     details[:requester] = { name: name, email: email } unless anonymous?
     details

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 require 'gds_api/test_helpers/support'
+require 'gds_api/test_helpers/support_api'
 
 def fill_in_valid_contact_details_and_description
   fill_in "Your name", :with => "test name"
@@ -26,15 +27,18 @@ describe "Contact" do
   end
 
   include GdsApi::TestHelpers::Support
+  include GdsApi::TestHelpers::SupportApi
   it "should let the user submit a request with contact details" do
     stub_post = stub_support_named_contact_creation(
       requester: { name: "test name", email: "a@a.com" },
       details: "test text details",
+      user_specified_url: nil,
       link: nil,
       javascript_enabled: false,
       user_agent: nil,
       referrer: nil,
-      url: "#{Plek.new.website_root}/contact/govuk"
+      url: "#{Plek.new.website_root}/contact/govuk",
+      path: "/contact/govuk",
     )
 
     visit "/contact/govuk"
@@ -64,10 +68,12 @@ describe "Contact" do
     stub_post = stub_support_long_form_anonymous_contact_creation(
       details: "test text details",
       link: nil,
+      user_specified_url: nil,
       javascript_enabled: false,
       user_agent: nil,
       referrer: nil,
-      url: "#{Plek.new.website_root}/contact/govuk"
+      url: "#{Plek.new.website_root}/contact/govuk",
+      path: "/contact/govuk",
     )
 
     visit "/contact/govuk"


### PR DESCRIPTION
... instead of to `support` (using the endpoint introduced [here](https://github.com/alphagov/support-api/pull/16)).
