### PR TITLE
Save URL when coming direct to the contact form

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -60,6 +60,16 @@
 
   GOVUK.feedback.prepopulateFormBasedOnReferrer = function () {
       $('#link').val(document.referrer);
+      /* pre-select the "A specific page" if the form was linked to directly */
+      if (document.referrer && !(GOVUK.feedback.getPathFor(document.referrer) == "/contact")) {
+        $('#location-specific').click();
+      }
+  }
+
+  GOVUK.feedback.getPathFor = function (url) {
+      var link = document.createElement("a");
+      link.href = url;
+      return link.pathname;
   }
 
   GOVUK.feedback.init = function () {


### PR DESCRIPTION
This change will automatically set the "A specific page" radio button
on the public contact form if the referrer isn't the interstitial (`www.gov.uk/contact`)
page.

This is useful whenever there is a direct link to the public form (eg from
`www.gov.uk/service-manual`); in those cases, this change will mean that the
specific page URL will be captured without user intervention. For users coming
from `/contact`, they will continue having 'What's it to do with?' default to
'The whole site'.

/cc @futurefabric @dsingleton 
