### PR TITLE
Fix index page alignment

### DIFF
--- a/app/assets/stylesheets/views/feedback.scss
+++ b/app/assets/stylesheets/views/feedback.scss
@@ -3,20 +3,12 @@
   header.page-header {
 
     div {
-      padding: 20px 30px;
-
-      @include media(mobile) {
-        padding: 15px;
-      }
-
       h1 {
         @include bold-48;
         width: 75%;
-        padding: 20px 0;
 
         @include media(mobile) {
           width: auto;
-          padding: 0 0 15px;
         }
       }
 
@@ -27,7 +19,7 @@
       }
     }
   }
-  
+
   .inner {
     padding: 0;
     margin: 0;
@@ -37,7 +29,6 @@
   .contact-container {
     background-color: #fff;
     min-height: 500px;
-    padding: 0 30px 45px 30px;
 
     .contact-form {
       p {
@@ -75,12 +66,7 @@
     }
 
     @include media(mobile) {
-      padding: 0 15px 30px 15px;
       min-height: auto;
-    }
-
-    @include ie-lte(8) {
-      padding: 0 3.5% 30px;
     }
 
     ul {
@@ -96,9 +82,6 @@
           margin-top: 3em;
           p {
             @include core-24;
-            // a {
-            //   text-decoration: none;
-            // }
           }
         }
 


### PR DESCRIPTION
After the changes to grids, the index page is misaligned. This commit
fixes the alignment by removing padding that's unnecessary.

Before (desktop):
![image](https://cloud.githubusercontent.com/assets/23801/7183460/7cfe3cc4-e44f-11e4-8f66-7314ebcaaa71.png)
After (desktop):
![image](https://cloud.githubusercontent.com/assets/23801/7183479/967d55a4-e44f-11e4-9187-687081bf1417.png)

Before (mobile):
![image](https://cloud.githubusercontent.com/assets/23801/7183503/b5c7d100-e44f-11e4-806d-9cf26598e2e4.png)
After (mobile):
![image](https://cloud.githubusercontent.com/assets/23801/7183512/cbe20c6c-e44f-11e4-897d-924700077bdd.png)
