### PR TITLE
Bump slimmer for rendering app meta tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '3.2.18'
 if ENV['SLIMMER_DEV']
   gem "slimmer", :path => '../slimmer'
 else
-  gem "slimmer", '8.1.0'
+  gem "slimmer", '8.2.1'
 end
 
 gem "unicorn", '4.3.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     simplecov-html (0.5.3)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (8.1.0)
+    slimmer (8.2.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -197,7 +197,7 @@ DEPENDENCIES
   shoulda-matchers (= 2.4.0)
   simplecov (= 0.6.4)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 8.1.0)
+  slimmer (= 8.2.1)
   statsd-ruby (= 1.2.1)
   uglifier (= 2.1.2)
   unicorn (= 4.3.1)


### PR DESCRIPTION
So we can track which application renders which page in analytics update
slimmer for a new version which outputs the rendering application.

This contains both https://github.com/alphagov/slimmer/pull/126 and https://github.com/alphagov/slimmer/pull/128
