### PR TITLE
Choose "A specific page" option more often

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -68,7 +68,7 @@
     $('#link').val(specificPage);
 
     // Choose "A specific page" option if the form was linked to directly
-    if (specificPage && !(GOVUK.feedback.getPathFor(document.referrer) == "/contact")) {
+    if (specificPage && !(GOVUK.feedback.getPathFor(specificPage) == "/contact")) {
       $('#location-specific').click();
     }
   }

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -228,7 +228,6 @@ describe "Contact" do
     click_on "GOV.UK form"
     stub_support_named_contact_creation
 
-    choose "location-specific"
     fill_in_valid_contact_details_and_description
     click_on "Send message"
 


### PR DESCRIPTION
Whenever there’s a specific page value that we’ve saved and prepopulated, default to “specific page” feedback type.

Follow on from https://github.com/alphagov/feedback/pull/153, fixes https://github.com/alphagov/feedback/pull/153#issuecomment-120001578:

> One design question: with this implementation, the specific page name is pre-populated but not selected in the feedback form. Unless the user actively selects the "a specific page" option, the URL won't make it through to the ticket. Should the "a specific page" be selected by default, or alternatively should the path be added to the form as a hidden parameter and then passed through into Zendesk?

cc @benilovj 