### PR TITLE
Specify NTA font for textareas

### DIFF
--- a/app/assets/stylesheets/views/contact.scss
+++ b/app/assets/stylesheets/views/contact.scss
@@ -35,6 +35,10 @@
    @include bold-19;
   }
 
+  textarea {
+    @include core-19;
+  }
+
   .contact-form textarea.full-size {
     height: 15em;
 


### PR DESCRIPTION
Textareas on https://www.gov.uk/contact/govuk don't currently specify a font, leading to browser default to be use. This specifies core-19 for them.