### PR TITLE
Don't load or run simplecov unnecessarily

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,8 @@ group :development, :test do
   gem 'govuk-lint'
   gem 'rspec-rails', '3.3.3'
   gem 'capybara', '2.5.0'
-  gem 'simplecov', '0.6.4'
-  gem 'simplecov-rcov', '0.2.3'
+  gem 'simplecov', '0.6.4', require: false
+  gem 'simplecov-rcov', '0.2.3', require: false
   gem 'webmock', '1.21.0', require: false
   gem 'poltergeist', '1.6.0'
   gem 'shoulda-matchers', '2.8.0'

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
+export USE_SIMPLECOV=true
 export GOVUK_ASSET_ROOT=http://static.dev.gov.uk
 export RAILS_ENV=test
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,9 @@
-require 'simplecov'
-require 'simplecov-rcov'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-SimpleCov.start 'rails'
+if ENV["USE_SIMPLECOV"]
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+end
 
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV["RAILS_ENV"] ||= 'test'


### PR DESCRIPTION
This will only load/run simplecov when `USE_SIMPLECOV` is exported.
Nobody cares about coverage locally and it slows the test suite down (a
little, but it's discernible no less)