### PR TITLE
Take the Support API bearer token from the env

### DIFF
--- a/config/initializers/support_app.rb
+++ b/config/initializers/support_app.rb
@@ -1,5 +1,6 @@
 require 'gds_api/support'
 require 'gds_api/support_api'
 
-Feedback.support = GdsApi::Support.new(Plek.current.find('support'), bearer_token: 'xxxxx')
+token = ENV.fetch('SUPPORT_API_BEARER_TOKEN', 'xxxxx')
+Feedback.support = GdsApi::Support.new(Plek.current.find('support'), bearer_token: token)
 Feedback.support_api = GdsApi::SupportApi.new(Plek.current.find('support-api'))


### PR DESCRIPTION
This environment variable is set by Puppet, and saves us having
to replace the `support_app.rb` initializer at deploy-time.

This can be merged any time, since until `alphagov-deployment` is changed, the initializer will be overwritten upon deploy.

Companion Puppet change: https://github.gds/gds/puppet/pull/3439

/cc @boffbowsh @jamiecobbett 