### PR TITLE
Explicitly specify log_level to :info in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,8 +30,7 @@ Feedback::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # See everything in the log (default is :info)
-  # config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags
   # config.log_tags = [ :subdomain, :uuid ]


### PR DESCRIPTION
This silences a deprecation warning; from Rails 5.0, the default
loglevel is :debug in all environments.

/cc @boffbowsh @benlovell 