### PR TITLE
Upgrade Slimmer, explicitly set 'wrapper' layout

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '4.2.4'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '~> 8.2.1'
+  gem 'slimmer', '~> 9.0.0'
 end
 
 gem 'unicorn', '~> 4.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,7 +182,7 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    slimmer (8.2.1)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -245,7 +245,7 @@ DEPENDENCIES
   sass (~> 3.4.18)
   sass-rails (~> 5.0.4)
   shoulda-matchers (~> 2.8.0)
-  slimmer (~> 8.2.1)
+  slimmer (~> 9.0.0)
   statsd-ruby (~> 1.2.1)
   test-unit (= 3.1.3)
   uglifier (~> 2.7.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,9 @@ class ApplicationController < ActionController::Base
   rescue_from SpamError, with: :robot_script_submission_detected
   rescue_from GdsApi::BaseError, with: :unable_to_create_ticket_error
 
+  include Slimmer::Template
+  slimmer_template 'wrapper'
+
 protected
   def robot_script_submission_detected
     headers[Slimmer::Headers::SKIP_HEADER] = "1"


### PR DESCRIPTION
This should be a no-op change to app behaviour. The Slimmer default was 'wrapper'
before the upgrade, and is not explicitly set.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps not yet using `core_layout` should be explicitly
marked as such, so we can easily identify them as needing updating.

I had a quick look at what would be required to use a modern layout;

- `header_footer_only`:
 - buttons
 - subheading styles
- `core_layout`:
 - the above, plus...
 - breadcrumbs

[1] https://github.com/alphagov/slimmer/pull/136