### PR TITLE
Bump gds-api-adapters version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'sass-rails', '~> 5.0.4'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '24.4.0'
+  gem 'gds-api-adapters', '26.5.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,11 +56,11 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    domain_name (0.5.24)
+    domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (24.4.0)
+    gds-api-adapters (26.5.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -92,11 +92,11 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.6.2)
+    mime-types (2.99)
     mini_portile (0.6.2)
     minitest (5.8.0)
     multi_json (1.11.2)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
@@ -111,7 +111,7 @@ GEM
     power_assert (0.2.4)
     powerpack (0.1.1)
     rack (1.6.4)
-    rack-cache (1.2)
+    rack-cache (1.5.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -232,7 +232,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.5.0)
-  gds-api-adapters (= 24.4.0)
+  gds-api-adapters (= 26.5.0)
   govuk-lint
   govuk_frontend_toolkit (= 1.6.0)
   invalid_utf8_rejector


### PR DESCRIPTION
In this [version](https://github.com/alphagov/gds-api-adapters/pull/404), SpecialistRoutePublisher now uses V2 of the Publishing
API client.

Tested on the VM, still works ok.

https://trello.com/c/fLsUOmuv/196-spike-contact-us-page