### PR TITLE
Page improvements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'sass-rails', '~> 5.0.4'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '36.0.0'
+  gem 'gds-api-adapters', '36.3.0'
 end
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'sass-rails', '~> 5.0.4'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '26.5.0'
+  gem 'gds-api-adapters', '36.0.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,17 +57,17 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (26.5.0)
+    gds-api-adapters (36.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-lint (0.3.0)
@@ -93,7 +93,9 @@ GEM
       PriorityQueue (~> 0.1.2)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
     multi_json (1.11.2)
@@ -114,7 +116,7 @@ GEM
     power_assert (0.2.4)
     powerpack (0.1.1)
     rack (1.6.4)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -147,10 +149,10 @@ GEM
     raindrops (0.15.0)
     rake (11.2.2)
     request_store (1.2.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -213,7 +215,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -236,7 +238,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.5.0)
-  gds-api-adapters (= 26.5.0)
+  gds-api-adapters (= 36.0.0)
   govuk-lint
   govuk_frontend_toolkit (= 1.6.0)
   invalid_utf8_rejector

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
-    gds-api-adapters (36.0.0)
+    gds-api-adapters (36.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -238,7 +238,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.5.0)
-  gds-api-adapters (= 36.0.0)
+  gds-api-adapters (= 36.3.0)
   govuk-lint
   govuk_frontend_toolkit (= 1.6.0)
   invalid_utf8_rejector

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,7 +26,7 @@ protected
         headers[Slimmer::Headers::SKIP_HEADER] = "1"
         render nothing: true, status: 503
       end
-      format.js do
+      format.any(:js, :json) do
         response = "<p>Sorry, we're unable to receive your message right now.</p> " +
           "<p>We have other ways for you to provide feedback on the " +
           "<a href='/contact'>contact page</a>.</p>"

--- a/app/controllers/contact/govuk/page_improvements_controller.rb
+++ b/app/controllers/contact/govuk/page_improvements_controller.rb
@@ -10,6 +10,6 @@ class Contact::Govuk::PageImprovementsController < ApplicationController
   end
 
   def page_improvements_params
-    params.slice(:description, :email, :name, :path, :user_agent)
+    params.slice(:description, :email, :name, :url, :user_agent)
   end
 end

--- a/app/controllers/contact/govuk/page_improvements_controller.rb
+++ b/app/controllers/contact/govuk/page_improvements_controller.rb
@@ -1,0 +1,15 @@
+class Contact::Govuk::PageImprovementsController < ApplicationController
+  def create
+    begin
+      Feedback.support_api.create_page_improvement(page_improvements_params)
+
+      render json: { status: 'success' }
+    rescue GdsApi::HTTPUnprocessableEntity => e
+      render json: e.error_details, status: e.code
+    end
+  end
+
+  def page_improvements_params
+    params.slice(:description, :email, :name, :path)
+  end
+end

--- a/app/controllers/contact/govuk/page_improvements_controller.rb
+++ b/app/controllers/contact/govuk/page_improvements_controller.rb
@@ -1,9 +1,9 @@
 class Contact::Govuk::PageImprovementsController < ApplicationController
   def create
     begin
-      Feedback.support_api.create_page_improvement(page_improvements_params)
+      response = Feedback.support_api.create_page_improvement(page_improvements_params)
 
-      render json: { status: 'success' }
+      render json: { status: 'success' }, status: response.code
     rescue GdsApi::HTTPUnprocessableEntity => e
       render json: e.error_details, status: e.code
     end

--- a/app/controllers/contact/govuk/page_improvements_controller.rb
+++ b/app/controllers/contact/govuk/page_improvements_controller.rb
@@ -10,6 +10,6 @@ class Contact::Govuk::PageImprovementsController < ApplicationController
   end
 
   def page_improvements_params
-    params.slice(:description, :email, :name, :path)
+    params.slice(:description, :email, :name, :path, :user_agent)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,8 +13,8 @@ Feedback::Application.routes.draw do
 
     namespace :govuk do
       post 'problem_reports', to: "problem_reports#create", format: false
-
       post 'service-feedback', to: "service_feedback#create", format: false
+      resources 'page_improvements', only: [:create], format: false
     end
 
     get 'look-for-jobs', to: redirect("https://jobsearch.direct.gov.uk/ContactUs.aspx")

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -32,13 +32,12 @@ describe "Page improvements" do
   end
 
   it "responds successfully" do
-    stub_any_support_api_call
+    params = { description: "The title is the wrong colour." }
+    stub_create_page_improvement(params)
 
-    post "/contact/govuk/page_improvements",
-      { description: "The title is the wrong colour." }.to_json,
-      common_headers
+    post "/contact/govuk/page_improvements", params.to_json, common_headers
 
-    assert_response :success
+    expect(response.code).to eq('201')
     expect(response_hash).to include('status' => 'success')
   end
 

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+require 'gds_api/test_helpers/support_api'
+
+describe "Page improvements" do
+  include GdsApi::TestHelpers::SupportApi
+
+  let(:common_headers) { { "Accept" => "application/json", "Content-Type" => "application/json" } }
+
+  it "submits the feedback to the Support API" do
+    stub_any_support_api_call
+
+    post "/contact/govuk/page_improvements",
+      {
+        description: "The title is the wrong colour.",
+        path: "/path/to/page",
+        name: "Henry",
+        email: "henry@example.com",
+      }.to_json,
+      common_headers
+
+    expected_request = a_request(:post, Plek.current.find('support-api') + "/page-improvements")
+      .with(body: {
+        "description" => "The title is the wrong colour.",
+        "path" => "/path/to/page",
+        "name" => "Henry",
+        "email" => "henry@example.com",
+      })
+
+    expect(expected_request).to have_been_made
+  end
+
+  it "responds successfully" do
+    stub_any_support_api_call
+
+    post "/contact/govuk/page_improvements",
+      { description: "The title is the wrong colour." }.to_json,
+      common_headers
+
+    assert_response :success
+    expect(response_hash).to include('status' => 'success')
+  end
+
+  context "when the Support API isn't available" do
+    it "responds with an error" do
+      support_api_isnt_available
+
+      post "/contact/govuk/page_improvements",
+        { description: "The title is the wrong colour." }.to_json,
+        common_headers
+
+      assert_response :error
+      expect(response_hash).to include('status' => 'error')
+    end
+  end
+
+  it "returns an error if the required attributes aren't supplied" do
+    url = Plek.current.find('support-api') + "/page-improvements"
+    stub_request(:post, url)
+      .with(body: {}.to_json)
+      .to_return(
+        status: 422,
+        body: { status: 'error', errors: [{ description: "can't be blank" }]}.to_json,
+        headers: { "Content-Type" => "application/json; charset=utf-8" }
+      )
+
+    post "/contact/govuk/page_improvements",
+      {}.to_json,
+      common_headers
+
+    expect(response.code).to eq('422')
+    expect(response_hash).to include('status' => 'error')
+    expect(response_hash).to include('errors' => [{ 'description' => "can't be blank" }])
+  end
+
+  it "only sends permitted attributes to the Support API" do
+    stub_any_support_api_call
+
+    post "/contact/govuk/page_improvements",
+      {
+        description: "The title is the wrong colour.",
+        try_my_luck: "maliciousCode();"
+      }.to_json,
+      common_headers
+
+    expected_request = a_request(:post, Plek.current.find('support-api') + "/page-improvements")
+      .with(body: { "description" => "The title is the wrong colour." })
+
+    expect(expected_request).to have_been_made
+  end
+
+  def response_hash
+    JSON.parse(response.body)
+  end
+end

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -15,6 +15,7 @@ describe "Page improvements" do
         path: "/path/to/page",
         name: "Henry",
         email: "henry@example.com",
+        user_agent: 'Safari',
       }.to_json,
       common_headers
 
@@ -24,6 +25,7 @@ describe "Page improvements" do
         "path" => "/path/to/page",
         "name" => "Henry",
         "email" => "henry@example.com",
+        "user_agent" => "Safari",
       })
 
     expect(expected_request).to have_been_made

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -12,7 +12,7 @@ describe "Page improvements" do
     post "/contact/govuk/page_improvements",
       {
         description: "The title is the wrong colour.",
-        path: "/path/to/page",
+        url: "https://gov.uk/path/to/page",
         name: "Henry",
         email: "henry@example.com",
         user_agent: 'Safari',
@@ -22,7 +22,7 @@ describe "Page improvements" do
     expected_request = a_request(:post, Plek.current.find('support-api') + "/page-improvements")
       .with(body: {
         "description" => "The title is the wrong colour.",
-        "path" => "/path/to/page",
+        "url" => "https://gov.uk/path/to/page",
         "name" => "Henry",
         "email" => "henry@example.com",
         "user_agent" => "Safari",


### PR DESCRIPTION
# Why

The service manual wants a way to allow users to give positive feedback, as well as negative.

# What

This page improvements endpoint supports an 'Improve this page' widget that sends AJAX requests to send feedback to Zendesk. https://trello.com/c/HN1L3EfK/286-update-footer-feedback-component

The feedback request is forwarded to the support-api which performs the guts of the task.

This is failing pending https://github.com/alphagov/gds-api-adapters/pull/579

WARNING: This upgrades gds-api-adapters 10 major versions. A bit of a regression test is probably required :(