### PR TITLE
Update Slimmer and breadcrumbs from Slimmer::GovukComponents

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '~> 4.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '~> 9.0.1'
+  gem 'slimmer', '~> 10.0.0'
 end
 
 gem 'unicorn', '~> 4.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,13 +234,13 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    slimmer (9.0.1)
+    slimmer (10.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
       null_logger
       plek (>= 1.1.0)
-      rack (>= 1.3.5)
+      rack
       rest-client
     slop (3.6.0)
     sprockets (3.7.0)
@@ -303,7 +303,7 @@ DEPENDENCIES
   sass (~> 3.4.18)
   sass-rails (~> 5.0.4)
   shoulda-matchers (~> 2.8.0)
-  slimmer (~> 9.0.1)
+  slimmer (~> 10.0.0)
   statsd-ruby (~> 1.2.1)
   test-unit (= 3.1.3)
   uglifier (~> 2.7.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::BaseError, with: :unable_to_create_ticket_error
 
   include Slimmer::Template
+  include Slimmer::GovukComponents
   slimmer_template 'wrapper'
 
 protected

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -4,14 +4,16 @@ class ContactController < ApplicationController
   include Slimmer::Headers
 
   before_filter :set_cache_control, only: [:new, :index]
-  before_filter :setup_slimmer_artefact, only: :new
 
   def index
     @popular_links = CONTACT_LINKS.popular
     @long_tail_links = CONTACT_LINKS.long_tail
+    @breadcrumbs = [breadcrumbs.first]
   end
 
   def new
+    @breadcrumbs = breadcrumbs
+
     respond_to do |format|
       format.html do
         render :new
@@ -43,6 +45,19 @@ class ContactController < ApplicationController
   end
 
 private
+
+  def breadcrumbs
+    [
+      {
+        title: "Home",
+        url: '/'
+      },
+      {
+        title: 'Contact',
+        url: '/contact'
+      }
+    ]
+  end
 
   def respond_to_valid_submission(ticket)
     ticket.save
@@ -81,10 +96,6 @@ private
 
   def set_cache_control
     expires_in 10.minutes, public: true unless Rails.env.development?
-  end
-
-  def setup_slimmer_artefact
-    set_slimmer_dummy_artefact(section_name: "Contact", section_link: "/contact")
   end
 
   def technical_attributes

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -1,6 +1,5 @@
 <% content_for :title do "Contact GOV.UK" end %>
 
-
 <div class="inner">
   <%= form_for :contact, url: contact_govuk_path, as: :post, authenticity_token: false, html: { class: "contact-form" } do |f| %>
     <%= hidden_field_tag 'contact[url]', Plek.new.website_root + contact_govuk_path %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,11 @@
     <%= yield :section_meta_tags %>
   </head>
   <body class="full-width">
+    <div class="header-context"><!-- Deliberately empty. This will prevent Slimmer from adding the artefact-breadcrumb. --></div>
     <div id="wrapper">
       <main id="content" role="main" class="group category-page">
+        <%= render partial: 'govuk_component/breadcrumbs', locals: { breadcrumbs: @breadcrumbs } %>
+
         <header class="page-header group">
           <div class="full-width">
             <h1><%= yield :title %></h1>

--- a/spec/controllers/contact/foi_controller_spec.rb
+++ b/spec/controllers/contact/foi_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'gds_api/test_helpers/support'
 
 RSpec.describe Contact::FoiController, type: :controller do
+  render_views
+
   include GdsApi::TestHelpers::Support
 
   let(:valid_params) do

--- a/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
+++ b/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe Contact::Govuk::ProblemReportsController, type: :controller do
+  render_views
+
   before :each do
     allow_any_instance_of(ReportAProblemTicket).to receive(:save).and_return(true)
   end

--- a/spec/controllers/contact/govuk_controller_spec.rb
+++ b/spec/controllers/contact/govuk_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 require 'gds_api/test_helpers/support'
 
 RSpec.describe Contact::GovukController, type: :controller do
+  render_views
+
   include GdsApi::TestHelpers::Support
 
   let(:valid_params) do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,9 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+
+require 'slimmer/test_helpers/govuk_components'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -23,6 +26,11 @@ require 'rspec/rails'
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 RSpec.configure do |config|
+  include Slimmer::TestHelpers::GovukComponents
+
+  config.before(:each) do
+    stub_shared_component_locales
+  end
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,6 +31,7 @@ RSpec.configure do |config|
   config.before(:each) do
     stub_shared_component_locales
   end
+
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and
   # `post` in specs under `spec/controllers`.

--- a/spec/requests/foi_spec.rb
+++ b/spec/requests/foi_spec.rb
@@ -84,6 +84,6 @@ RSpec.describe "FOI", type: :request do
     expect(find_field('Your email address').value).to eq 'a@a.com'
     expect(find_field('Confirm your email address').value).to eq 'a@a.com'
 
-    no_web_calls_should_have_been_made
+    expect(a_request(:post, '/contact/foi')).not_to have_been_made
   end
 end

--- a/spec/support/govuk_contact.rb
+++ b/spec/support/govuk_contact.rb
@@ -17,11 +17,6 @@ RSpec.shared_examples_for "a GOV.UK contact" do
 
       expect(response.code).to eq("406")
     end
-
-    it "should send a dummy artefact to slimmer with a Contact section" do
-      expect(controller).to receive(:set_slimmer_dummy_artefact).with(section_name: "Contact", section_link: "/contact")
-      get :new
-    end
   end
 
   context "on POST" do

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -6,6 +6,10 @@ module WebmockHelper
   def no_web_calls_should_have_been_made
     expect(WebMock).not_to have_requested(:any, /.*/)
   end
+
+  def no_post_calls_should_have_been_made
+    expect(WebMock).not_to have_requested(:post, /.*/)
+  end
 end
 
 RSpec.configuration.include WebmockHelper, type: :request


### PR DESCRIPTION
The feeback app currently uses set_slimmer_dummy_artefact to make the
contact page show breadcrumbs.

This behaviour is deprecated in favour of using the breadcrumbs
component: http://govuk-component-guide.herokuapp.com/components/breadcrumbs

Trello:
https://trello.com/c/6Km63K2Z/402-feedback-app-use-component-for-breadcrumbs-and-upgrade-slimmer


`render_views` is a workaround for a known issue https://github.com/alphagov/slimmer/issues/170