### PR TITLE
Move to the new CI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,4 +42,5 @@ group :development, :test do
   gem 'shoulda-matchers', '~> 2.8.0'
   gem 'test-unit', '3.1.3'
   gem 'pry-byebug'
+  gem 'ci_reporter_rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,11 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    ci_reporter (2.0.0)
+      builder (>= 2.1.2)
+    ci_reporter_rspec (1.0.0)
+      ci_reporter (~> 2.0)
+      rspec (>= 2.14, < 4)
     cliver (0.3.2)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
@@ -192,6 +197,10 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (2.1.0)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
     rspec-core (3.4.4)
       rspec-support (~> 3.4.0)
     rspec-expectations (3.4.0)
@@ -288,6 +297,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.5.0)
+  ci_reporter_rspec
   gds-api-adapters (= 36.3.0)
   google-api-client (~> 0.9)
   govuk-lint

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,99 @@
+#!/usr/bin/env groovy
+
+REPOSITORY = 'feedback'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
+
+node('mongodb-2.4') {
+  def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
+
+  properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '50')
+      ),
+    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
+    [$class: 'ThrottleJobProperty',
+      categories: [],
+      limitOneJobWithMatchingParams: true,
+      maxConcurrentPerNode: 1,
+      maxConcurrentTotal: 0,
+      paramsToUseForLimit: 'feedback',
+      throttleEnabled: true,
+      throttleOption: 'category'],
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
+  try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
+    stage("Checkout") {
+      checkout scm
+    }
+
+    stage("Clean up workspace") {
+      govuk.cleanupGit()
+    }
+
+    stage("git merge") {
+      govuk.mergeMasterBranch()
+    }
+
+    stage("Configure Rails environment") {
+      govuk.setEnvar("RAILS_ENV", "test")
+    }
+
+    stage("Set up content schema dependency") {
+      govuk.contentSchemaDependency()
+      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
+    }
+
+    stage("bundle install") {
+      govuk.bundleApp()
+    }
+
+    stage("rubylinter") {
+      govuk.rubyLinter("app test lib")
+    }
+
+    stage("Precompile assets") {
+      govuk.precompileAssets()
+    }
+
+    stage("Run tests") {
+      govuk.runRakeTask("ci:setup:rspec default")
+    }
+
+    stage("Push release tag") {
+      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, "release_${env.BUILD_NUMBER}")
+    }
+
+    stage("Deploy to integration") {
+      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
+    }
+
+  } catch (e) {
+    currentBuild.result = "FAILED"
+    step([$class: 'Mailer',
+          notifyEveryUnstableBuild: true,
+          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
+          sendToIndividuals: true])
+    throw e
+  }
+}

--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'ci/reporter/rake/rspec'
 
 Feedback::Application.load_tasks


### PR DESCRIPTION
Trello: https://trello.com/c/g1Hc0uim/572-move-feedex-to-new-ci-infrastructure-1

The old CI infrastructure is in the process of being wound down so we need to move our apps to the new one.