### PR TITLE
Fix feedback app during deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ else
 end
 
 group :development, :test do
+  gem 'govuk-content-schema-test-helpers'
   gem 'govuk-lint'
   gem 'rspec-rails', '~> 3.4.0'
   gem 'capybara', '~> 2.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,8 @@ GEM
       multi_json (~> 1.11)
       os (~> 0.9)
       signet (~> 0.7)
+    govuk-content-schema-test-helpers (1.4.0)
+      json-schema (~> 2.5.1)
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
@@ -103,6 +105,8 @@ GEM
     invalid_utf8_rejector (0.0.2)
       rack (~> 1.0)
     json (1.8.3)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     jwt (1.5.6)
     kgio (2.10.0)
     link_header (0.0.8)
@@ -290,6 +294,7 @@ DEPENDENCIES
   capybara (~> 2.5.0)
   gds-api-adapters (= 36.3.0)
   google-api-client (~> 0.9)
+  govuk-content-schema-test-helpers
   govuk-lint
   govuk_frontend_toolkit (= 1.6.0)
   invalid_utf8_rejector

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -14,5 +14,10 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
   app lib spec
 fi
 
+# Clone govuk-content-schemas depedency for tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
+
 bundle exec rake
 bundle exec rake assets:precompile

--- a/lib/redirect_publisher.rb
+++ b/lib/redirect_publisher.rb
@@ -1,0 +1,37 @@
+require 'logger'
+require 'gds_api/publishing_api'
+require 'gds_api/publishing_api/special_route_publisher'
+
+class RedirectPublisher
+  attr_reader :logger, :publishing_app, :type, :publishing_api
+
+  def initialize(logger:, publishing_app:, type: "exact", publishing_api:)
+    @logger = logger
+    @publishing_app = publishing_app
+    @type = type
+    @publishing_api = publishing_api
+  end
+
+  def call(content_id:, current_base_path:, destination_path:)
+    logger.info("Registering redirect #{content_id}: '#{current_base_path}' -> '#{destination_path}'")
+
+    redirect = {
+      "content_id" => content_id,
+      "base_path" => current_base_path,
+      "schema_name" => "redirect",
+      "document_type" => "redirect",
+      "publishing_app" => publishing_app,
+      "update_type" => "major",
+      "redirects" => [
+        {
+          "path" => current_base_path,
+          "type" => type,
+          "destination" => destination_path
+        }
+      ]
+    }
+
+    publishing_api.put_content(content_id, redirect)
+    publishing_api.publish(content_id, "major")
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,48 +1,11 @@
-require 'logger'
-require 'gds_api/publishing_api'
-require 'gds_api/publishing_api/special_route_publisher'
-
-class RedirectPublisher
-  attr_reader :logger, :publishing_app, :type, :publishing_api
-
-  def initialize(logger:, publishing_app:, type: "exact", publishing_api:)
-    @logger = logger
-    @publishing_app = publishing_app
-    @type = type
-    @publishing_api = publishing_api
-  end
-
-  def call(content_id, base_path, destination_path)
-    logger.info("Registering redirect #{content_id}: '#{base_path}' -> '#{destination_path}'")
-
-    redirect = {
-      "content_id" => content_id,
-      "base_path" => base_path,
-      "format" => "redirect",
-      "publishing_app" => publishing_app,
-      "update_type" => "major",
-      "redirects" => [
-        {
-          "path" => base_path,
-          "type" => type,
-          "destination" => destination_path
-        }
-      ]
-    }
-
-    publishing_api.put_content(content_id, redirect)
-    publishing_api.publish(content_id, "major")
-  end
-end
-
-def publishing_api
-  GdsApi::PublishingApiV2.new(
-    Plek.new.find('publishing-api'),
-    bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
-  )
-end
-
 namespace :publishing_api do
+  def publishing_api
+    GdsApi::PublishingApiV2.new(
+      Plek.new.find('publishing-api'),
+      bearer_token: ENV['PUBLISHING_API_BEARER_TOKEN'] || 'example'
+    )
+  end
+
   desc 'Publish special routes via publishing api'
   task :publish_special_routes do
     logger = Logger.new(STDOUT)
@@ -60,13 +23,50 @@ namespace :publishing_api do
       rendering_app: 'feedback'
     )
 
-    redirect_publisher = RedirectPublisher.new(logger: logger, publishing_app: 'feedback', publishing_api: publishing_api)
-    redirect_publisher.call('be88ff3e-deb3-4a6e-b6ac-d6d12b50ac3d', '/feedback', '/contact')
-    redirect_publisher.call('16a89a3b-bd41-4bce-adaf-7505b844632f', '/feedback/contact', '/contact/govuk')
-    redirect_publisher.call('a6d9bafd-f69b-4d2f-a002-c7547473e152', '/feedback/foi', '/contact/foi')
-    redirect_publisher.call('d9f4ef65-4efb-4865-a562-c41d9794b796', '/contact/dvla', '/contact-the-dvla')
-    redirect_publisher.call('80ea2f60-c900-4c73-a129-d5418fc7d12d', '/contact/passport-advice-line', '/passport-advice-line')
-    redirect_publisher.call('4dee002d-6d26-47ff-b192-7e0392805f9f', '/contact/student-finance-england', '/contact-student-finance-england')
-    redirect_publisher.call('b7f6e48e-9d2c-4789-a64f-455921dca0d0', '/contact/jobcentre-plus', '/contact-jobcentre-plus')
+    redirect_publisher = RedirectPublisher.new(
+      logger: logger,
+      publishing_app: 'feedback',
+      publishing_api: publishing_api
+    )
+
+    redirect_publisher.call(
+      content_id: 'be88ff3e-deb3-4a6e-b6ac-d6d12b50ac3d',
+      current_base_path: '/feedback',
+      destination_path: '/contact'
+    )
+
+    redirect_publisher.call(
+      content_id: '16a89a3b-bd41-4bce-adaf-7505b844632f',
+      current_base_path: '/feedback/contact',
+      destination_path: '/contact/govuk'
+    )
+
+    redirect_publisher.call(
+      content_id: 'a6d9bafd-f69b-4d2f-a002-c7547473e152',
+      current_base_path: '/feedback/foi',
+      destination_path: '/contact/foi')
+
+    redirect_publisher.call(
+      content_id: 'd9f4ef65-4efb-4865-a562-c41d9794b796',
+      current_base_path: '/contact/dvla',
+      destination_path: '/contact-the-dvla')
+
+    redirect_publisher.call(
+      content_id: '80ea2f60-c900-4c73-a129-d5418fc7d12d',
+      current_base_path: '/contact/passport-advice-line',
+      destination_path: '/passport-advice-line'
+    )
+
+    redirect_publisher.call(
+      content_id: '4dee002d-6d26-47ff-b192-7e0392805f9f',
+      current_base_path: '/contact/student-finance-england',
+      destination_path: '/contact-student-finance-england'
+    )
+
+    redirect_publisher.call(
+      content_id: 'b7f6e48e-9d2c-4789-a64f-455921dca0d0',
+      current_base_path: '/contact/jobcentre-plus',
+      destination_path: '/contact-jobcentre-plus'
+    )
   end
 end

--- a/spec/lib/redirect_publisher_spec.rb
+++ b/spec/lib/redirect_publisher_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+require './lib/redirect_publisher'
+require 'govuk-content-schema-test-helpers/rspec_matchers'
+
+RSpec.describe RedirectPublisher do
+  GovukContentSchemaTestHelpers.configure do |config|
+    config.schema_type = 'publisher_v2'
+    config.project_root = Rails.root
+  end
+
+  let(:logger) { double(:logger) }
+
+  it "publishes redirects" do
+    content_id = SecureRandom.uuid
+    current_base_path = "/feedback"
+    destination_path = "/contact"
+
+    expected_redirect = {
+      "content_id" => content_id,
+      "base_path" => current_base_path,
+      "schema_name" => "redirect",
+      "document_type" => "redirect",
+      "publishing_app" => "feedback",
+      "update_type" => "major",
+      "redirects" => [
+        {
+          "path" => current_base_path,
+          "type" => "exact",
+          "destination" => destination_path,
+        }
+      ]
+    }
+
+    api = double(:publishing_api)
+
+    expect(api).to receive(:put_content).with(content_id, expected_redirect)
+    expect(api).to receive(:publish).once.with(content_id, 'major')
+
+    expect(logger).to receive(:info)
+      .with("Registering redirect #{content_id}: '#{current_base_path}' -> '#{destination_path}'")
+
+    redirect_publisher = RedirectPublisher.new(
+      logger: logger,
+      publishing_app: 'feedback',
+      type: "exact",
+      publishing_api: api,
+    )
+
+    redirect_publisher.call(
+      content_id: content_id,
+      current_base_path: current_base_path,
+      destination_path: destination_path,
+    )
+  end
+
+  it "publishes redirects that are valid" do
+    content_id = SecureRandom.uuid
+    current_base_path = "/feedback"
+    destination_path = "/contact"
+
+    api = double(:publishing_api)
+    expect(api).to receive(:put_content).with(an_instance_of(String), be_valid_against_schema('redirect'))
+    expect(api).to receive(:publish).once.with(content_id, 'major')
+
+    expect(logger).to receive(:info)
+      .with("Registering redirect #{content_id}: '#{current_base_path}' -> '#{destination_path}'")
+
+    redirect_publisher = RedirectPublisher.new(
+      logger: logger,
+      publishing_app: 'feedback',
+      type: "exact",
+      publishing_api: api,
+    )
+
+    redirect_publisher.call(
+      content_id: content_id,
+      current_base_path: current_base_path,
+      destination_path: destination_path,
+    )
+  end
+end


### PR DESCRIPTION
`format` field has been deprecated.
The correct structure is to use `schema_name` & `document_type`.

Trello: https://trello.com/c/n61y8RR7/421-fix-feedback-app-deploy