### PR TITLE
Amend node restriction

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 REPOSITORY = 'feedback'
 DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
-node('mongodb-2.4') {
+node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   properties([


### PR DESCRIPTION
Trello: https://trello.com/c/g1Hc0uim/572-move-feedback-to-new-ci-infrastructure-1

https://ci.dev.publishing.service.gov.uk/job/govuk_feedback/configure
doesn't restrict where this build should be run so we can omit the
mongodb-2.4 tag here