### PR TITLE
Named contact spam reduction attempt

### DIFF
--- a/app/views/contact/foi/new.html.erb
+++ b/app/views/contact/foi/new.html.erb
@@ -8,7 +8,8 @@
   <%= form_for :contact, url: contact_foi_path, as: :post, authenticity_token: false, html: { class: "contact-form" } do |f| %>
     <%= hidden_field_tag 'foi[url]', Plek.new.website_root + contact_foi_path %>
 
-    <input type="text" id="val" name="foi[val]" style="display:none"/>
+    <%= render partial: "shared/spam_honeypot", locals: { form_name: 'foi' } %>
+
     <%= render "shared/error_summary" %>
 
     <fieldset>

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -6,7 +6,8 @@
 
     <p>Remember, the <a href="/help">help pages</a> have answers to the most common questions about the GOV.UK website. You can use the form below to ask a question, report a problem or suggest an improvement we can make to GOV.UK.</p>
 
-    <input type="text" id="val" name="contact[val]" style="display:none"/>
+    <%= render partial: "shared/spam_honeypot", locals: { form_name: 'contact' } %>
+
     <%= render "shared/error_summary" %>
 
     <fieldset id="location">

--- a/app/views/shared/_spam_honeypot.html.erb
+++ b/app/views/shared/_spam_honeypot.html.erb
@@ -1,0 +1,5 @@
+<%# Honeypot field intended to reduce spam %>
+<div class="visually-hidden" aria-hidden="true">
+  <label for="val">Ignore if you're not a robot</label>
+  <input type="text" tabindex="-1" autocomplete="off" id="val" name="<%= "#{form_name}" %>[val]"/>
+</div>


### PR DESCRIPTION
[Trello card](https://trello.com/c/AUgP3juS/93-chinese-spam-user-support-zendesk-tickets)

The user support team have received large numbers of spam Named Contact requests in zendesk during January 2017.

This PR is an attempt to reduce the number of successful spam requests made by automated scripts, by changing the honeypot style and moving the rule to an external file.

