### PR TITLE
Fix Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
-require 'ci/reporter/rake/rspec'
+require 'ci/reporter/rake/rspec' unless Rails.env.production?
 
 Feedback::Application.load_tasks


### PR DESCRIPTION
Trello: https://trello.com/c/g1Hc0uim/572-move-feedback-to-new-ci-infrastructure-1

Rspec is not required in production environment, as no tests are run
there.