### PR TITLE
Advanced assisted digital help with fees survey

### DIFF
--- a/app/controllers/contact/govuk/assisted_digital_help_with_fees_feedback_controller.rb
+++ b/app/controllers/contact/govuk/assisted_digital_help_with_fees_feedback_controller.rb
@@ -6,7 +6,7 @@ module Contact
     private
 
       def ticket_class
-        AssistedDigitalHelpWithFeesFeedback
+        MultiTicket.new(AssistedDigitalHelpWithFeesFeedback, ServiceFeedback)
       end
 
       def type

--- a/app/models/multi_ticket.rb
+++ b/app/models/multi_ticket.rb
@@ -1,0 +1,39 @@
+class MultiTicket
+  attr_reader :ticket_types
+  def initialize(*ticket_types)
+    @ticket_types = ticket_types
+  end
+
+  def new(data)
+    Instance.new(@ticket_types.map { |ticket_type| ticket_type.new(data) })
+  end
+
+  class Instance
+    attr_reader :tickets
+    def initialize(tickets)
+      @tickets = tickets
+    end
+
+    def valid?
+      @tickets.all?(&:valid?)
+    end
+
+    def save
+      @tickets.each(&:save)
+    end
+
+    def spam?
+      @tickets.any?(&:spam?)
+    end
+
+    def errors
+      errors = ActiveModel::Errors.new(self)
+      @tickets.map(&:errors).each do |ticket_errors|
+        ticket_errors.each do |attribute, error|
+          errors.add(attribute, error)
+        end
+      end
+      errors
+    end
+  end
+end

--- a/spec/models/assisted_digital_help_with_fees_feedback_spec.rb
+++ b/spec/models/assisted_digital_help_with_fees_feedback_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
   include ValidatorHelper
   include ActiveSupport::Testing::TimeHelpers
 
-  context "a valid feedback item" do
+  context "a minimal valid feedback item" do
     subject { described_class.new(options) }
     let(:options) do
       {
-        assistance: 'no',
+        assistance_received: 'no',
         service_satisfaction_rating: "5",
         improvement_comments: "Could it be any more black",
         slug: "some-transaction",
@@ -44,8 +44,60 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
   end
 
   context 'validations' do
-    it { is_expected.not_to allow_value(nil).for(:assistance) }
-    it { is_expected.to validate_inclusion_of(:assistance).in_array(%w(no some all)) }
+    it { is_expected.not_to allow_value(nil).for(:assistance_received) }
+    it { is_expected.to validate_inclusion_of(:assistance_received).in_array(%w(yes no)) }
+
+    context 'when no assistance was received' do
+      subject { described_class.new(assistance_received: 'no') }
+
+      it { is_expected.to allow_value(nil).for(:assistance_received_comments) }
+      it { is_expected.to allow_value(nil).for(:assistance_provided_by) }
+      it { is_expected.to allow_value(nil).for(:assistance_satisfaction_rating) }
+      it { is_expected.to allow_value(nil).for(:assistance_provided_by_other) }
+      it { is_expected.to allow_value(nil).for(:assistance_improvement_comments) }
+    end
+
+    context 'when assistance was received' do
+      subject { described_class.new(assistance_received: 'yes') }
+
+      it { is_expected.not_to allow_value(nil).for(:assistance_received_comments) }
+      it { is_expected.to validate_length_of(:assistance_received_comments).is_at_most(Ticket::FIELD_MAXIMUM_CHARACTER_COUNT).with_long_message(/can be max 1250 characters/) }
+      it { is_expected.not_to allow_value(nil).for(:assistance_provided_by) }
+      it { is_expected.to validate_inclusion_of(:assistance_provided_by).in_array(%w(friend-relative work-colleague government-staff other)) }
+      it { is_expected.to allow_value(nil).for(:assistance_improvement_comments) }
+
+      context 'and assistance was provided by "other"' do
+        subject { described_class.new(assistance_received: 'yes', assistance_provided_by: 'other') }
+
+        it { is_expected.not_to allow_value(nil).for(:assistance_provided_by_other) }
+        it { is_expected.not_to allow_value(nil).for(:assistance_satisfaction_rating) }
+        it { is_expected.to validate_inclusion_of(:assistance_satisfaction_rating).in_array(('1'..'5').to_a) }
+        it { is_expected.to validate_length_of(:assistance_improvement_comments).is_at_most(Ticket::FIELD_MAXIMUM_CHARACTER_COUNT).with_long_message(/can be max 1250 characters/) }
+      end
+
+      context 'and assistance was provided by "government-staff"' do
+        subject { described_class.new(assistance_received: 'yes', assistance_provided_by: 'government-staff') }
+
+        it { is_expected.to allow_value(nil).for(:assistance_provided_by_other) }
+        it { is_expected.not_to allow_value(nil).for(:assistance_satisfaction_rating) }
+        it { is_expected.to validate_inclusion_of(:assistance_satisfaction_rating).in_array(('1'..'5').to_a) }
+        it { is_expected.to validate_length_of(:assistance_improvement_comments).is_at_most(Ticket::FIELD_MAXIMUM_CHARACTER_COUNT).with_long_message(/can be max 1250 characters/) }
+      end
+
+      context 'and assistance was provided by "work-colleague"' do
+        subject { described_class.new(assistance_received: 'yes', assistance_provided_by: 'work-colleague') }
+
+        it { is_expected.to allow_value(nil).for(:assistance_provided_by_other) }
+        it { is_expected.to allow_value(nil).for(:assistance_satisfaction_rating) }
+      end
+
+      context 'and assistance was provided by "friend-relative"' do
+        subject { described_class.new(assistance_received: 'yes', assistance_provided_by: 'friend-relative') }
+
+        it { is_expected.to allow_value(nil).for(:assistance_provided_by_other) }
+        it { is_expected.to allow_value(nil).for(:assistance_satisfaction_rating) }
+      end
+    end
 
     it { is_expected.not_to allow_value(nil).for(:service_satisfaction_rating) }
     it { is_expected.to validate_inclusion_of(:service_satisfaction_rating).in_array(('1'..'5').to_a) }
@@ -60,7 +112,12 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
     subject { described_class.new(params).as_row_data }
     let(:params) do
       {
-        assistance: 'no',
+        assistance_received: 'yes',
+        assistance_received_comments: 'I was walked through the online process on my own computer',
+        assistance_provided_by: 'other',
+        assistance_provided_by_other: 'A helpful librarian at my local drop-in center',
+        assistance_satisfaction_rating: '5',
+        assistance_improvement_comments: 'Make it easy to book a session',
         service_satisfaction_rating: "4",
         improvement_comments: "it was fine",
         slug: "some-transaction",
@@ -71,51 +128,150 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
       }
     end
 
-    it 'exposes an array of 10 elements' do
-      expect(subject.size).to eq 10
+    it 'exposes an array of 15 elements' do
+      expect(subject.size).to eq 15
     end
 
-    it 'exposes `assistance` in the first cell' do
-      expect(subject[0]).to eq 'no'
+    it 'exposes `assistance_received` in the first cell' do
+      expect(subject[0]).to eq 'yes'
     end
 
-    it 'exposes `service_satisfaction_rating` in the second cell as an integer' do
-      expect(subject[1]).to eq 4
+    context 'when assistance was received' do
+      let(:params) { super().merge(assistance_received: 'yes') }
+      it 'exposes `assistance_received_comments` in the second cell' do
+        expect(subject[1]).to eq 'I was walked through the online process on my own computer'
+      end
+
+      it 'exposes `assistance_provided_by` in the third cell' do
+        expect(subject[2]).to eq 'other'
+      end
+
+      context 'when assistance was provided by "other"' do
+        let(:params) { super().merge(assistance_provided_by: 'other') }
+
+        it 'exposes `assistance_provided_by_other` in the fourth cell' do
+          expect(subject[3]).to eq 'A helpful librarian at my local drop-in center'
+        end
+
+        it 'exposes `assistance_satisfaction_rating` in the fifth cell as an integer' do
+          expect(subject[4]).to eq 5
+        end
+
+        it 'exposes `assistance_improvement_comments` in the sixth cell' do
+          expect(subject[5]).to eq 'Make it easy to book a session'
+        end
+      end
+
+      context 'when assistance was provided by "government-staff"' do
+        let(:params) { super().merge(assistance_provided_by: 'government-staff') }
+
+        it 'exposes nil in the fourth cell' do
+          expect(subject[3]).to be_nil
+        end
+
+        it 'exposes `assistance_satisfaction_rating` in the fifth cell as an integer' do
+          expect(subject[4]).to eq 5
+        end
+
+        it 'exposes `assistance_improvement_comments` in the sixth cell' do
+          expect(subject[5]).to eq 'Make it easy to book a session'
+        end
+      end
+
+      context 'when assistance was provided by "work-colleague"' do
+        let(:params) { super().merge(assistance_provided_by: 'work-colleague') }
+
+        it 'exposes nil in the fourth cell' do
+          expect(subject[3]).to be_nil
+        end
+
+        it 'exposes nil in the fifth cell as an integer' do
+          expect(subject[4]).to be_nil
+        end
+
+        it 'exposes nil in the sixth cell' do
+          expect(subject[5]).to be_nil
+        end
+      end
+
+      context 'when assistance was provided by "friend-relative"' do
+        let(:params) { super().merge(assistance_provided_by: 'friend-relative') }
+
+        it 'exposes nil in the fourth cell' do
+          expect(subject[3]).to be_nil
+        end
+
+        it 'exposes nil in the fifth cell as an integer' do
+          expect(subject[4]).to be_nil
+        end
+
+        it 'exposes nil in the sixth cell' do
+          expect(subject[5]).to be_nil
+        end
+      end
     end
 
-    it 'exposes `improvement_comments` in the third cell' do
-      expect(subject[2]).to eq "it was fine"
+    context 'when assistance was not received' do
+      let(:params) { super().merge(assistance_received: 'no') }
+
+      it 'exposes nil in the second cell' do
+        expect(subject[1]).to be_nil
+      end
+
+      it 'exposes nil in the third cell' do
+        expect(subject[2]).to be_nil
+      end
+
+      it 'exposes nil in the fourth cell' do
+        expect(subject[3]).to be_nil
+      end
+
+      it 'exposes nil in the fifth cell' do
+        expect(subject[4]).to be_nil
+      end
+
+      it 'exposes nil in the sixth cell' do
+        expect(subject[5]).to be_nil
+      end
     end
 
-    it 'exposes `slug` in the fourth cell' do
-      expect(subject[3]).to eq "some-transaction"
+    it 'exposes `service_satisfaction_rating` in the seventh cell as an integer' do
+      expect(subject[6]).to eq 4
     end
 
-    it 'exposes `user_agent` in the fifth cell' do
-      expect(subject[4]).to eq "Mozilla-compatible, Foofari WebKat Chrume 111111.01"
+    it 'exposes `improvement_comments` in the eigth cell' do
+      expect(subject[7]).to eq "it was fine"
     end
 
-    it 'exposes `javascript_enabled` as a boolean in the sixth cell' do
-      expect(subject[5]).to eq true
+    it 'exposes `slug` in the ninth cell' do
+      expect(subject[8]).to eq "some-transaction"
     end
 
-    it 'exposes the referrer in the seventh cell' do
-      expect(subject[6]).to eq "https://www.some-transaction.service.gov/uk/completed"
+    it 'exposes `user_agent` in the tenth cell' do
+      expect(subject[9]).to eq "Mozilla-compatible, Foofari WebKat Chrume 111111.01"
     end
 
-    it 'extracts the path from the url and exposes it in the eight cell' do
-      expect(subject[7]).to eq '/done/some-transaction'
+    it 'exposes `javascript_enabled` as a boolean in the eleventh cell' do
+      expect(subject[10]).to eq true
     end
 
-    it 'exposes `url` in the ninth cell' do
-      expect(subject[8]).to eq 'https://www.gov.uk/done/some-transaction'
+    it 'exposes the referrer in the twelfth cell' do
+      expect(subject[11]).to eq "https://www.some-transaction.service.gov/uk/completed"
     end
 
-    it 'exposes a timestamp for the current time in the tenth cell' do
+    it 'extracts the path from the url and exposes it in the thirteenth cell' do
+      expect(subject[12]).to eq '/done/some-transaction'
+    end
+
+    it 'exposes `url` in the fourteenth cell' do
+      expect(subject[13]).to eq 'https://www.gov.uk/done/some-transaction'
+    end
+
+    it 'exposes a timestamp for the current time in the fifteenth cell' do
       # travel_to doesn't respect usec apparently
       the_past = 13.years.ago.change(usec: 0)
       travel_to(the_past) do
-        expect(subject[9]).to eq the_past
+        expect(subject[14]).to eq the_past
       end
     end
 
@@ -123,59 +279,75 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
       context 'is provided in params' do
         let(:params) { super().merge(javascript_enabled: "1") }
         it 'exposes a true value' do
-          expect(subject[5]).to eq true
+          expect(subject[10]).to eq true
         end
       end
 
       context 'is not provided in params' do
         let(:params) { super().except(:javascript_enabled) }
         it 'exposes a false value' do
-          expect(subject[5]).to eq false
+          expect(subject[10]).to eq false
         end
       end
     end
 
-    context "with empty comments" do
+    context "with empty assistance_received_comments" do
+      let(:params) { super().merge(assistance_received_comments: "") }
+
+      it 'exposes a nil value in the assistance_received_comments cell' do
+        expect(subject[1]).to be_nil
+      end
+    end
+
+    context "with empty assistance_improvement_comments" do
+      let(:params) { super().merge(assistance_improvement_comments: "") }
+
+      it 'exposes a nil value in the assistance_improvement_comments cell' do
+        expect(subject[5]).to be_nil
+      end
+    end
+
+    context "with empty improvement_comments" do
       let(:params) { super().merge(improvement_comments: "") }
 
-      it 'exposes a nil value in the third cell' do
-        expect(subject[2]).to be_nil
+      it 'exposes a nil value in the eighth cell' do
+        expect(subject[7]).to be_nil
       end
     end
 
     context "with an invalid URL" do
       let(:params) { super().merge(url: "```") }
 
-      it 'exposes a blank path in the eighth cell' do
-        expect(subject[7]).to be_nil
+      it 'exposes a blank path in the path cell' do
+        expect(subject[12]).to be_nil
       end
 
-      it 'exposes a blank URL in the ninth cell' do
-        expect(subject[8]).to be_nil
+      it 'exposes a blank URL in the url cell' do
+        expect(subject[13]).to be_nil
       end
     end
 
     context "with a relative URL" do
       let(:params) { super().merge(url: "/done/some-transaction") }
 
-      it 'exposes an absolute URL in the ninth cell' do
-        expect(subject[8]).to eq "#{Plek.new.website_root}/done/some-transaction"
+      it 'exposes an absolute URL in the url cell' do
+        expect(subject[13]).to eq "#{Plek.new.website_root}/done/some-transaction"
       end
     end
 
     context "with an invalid referrer" do
       let(:params) { super().merge(referrer: "```") }
 
-      it 'exposes a blank referrer in the seventh cell' do
-        expect(subject[6]).to be_nil
+      it 'exposes a blank referrer in the referrer cell' do
+        expect(subject[11]).to be_nil
       end
     end
 
     context "with a relative referrer" do
       let(:params) { super().merge(referrer: "/some-transaction/completed") }
 
-      it 'exposes an absolute referrer in the seventh cell' do
-        expect(subject[6]).to eq "#{Plek.new.website_root}/some-transaction/completed"
+      it 'exposes an absolute referrer in the referrer cell' do
+        expect(subject[11]).to eq "#{Plek.new.website_root}/some-transaction/completed"
       end
     end
   end

--- a/spec/models/multi_ticket_spec.rb
+++ b/spec/models/multi_ticket_spec.rb
@@ -1,0 +1,161 @@
+require 'rails_helper'
+
+RSpec.describe MultiTicket, type: :model do
+  subject { described_class.new(ServiceFeedback, AssistedDigitalHelpWithFeesFeedback) }
+
+  context '#new' do
+    it 'stores the supplied ticket types' do
+      expect(subject.ticket_types).to eq [ServiceFeedback, AssistedDigitalHelpWithFeesFeedback]
+    end
+  end
+
+  context '.new' do
+    subject { super().new(assistance_received: 'no', service_satisfaction_rating: '1') }
+
+    it 'returns a multiticket instance' do
+      expect(subject).to be_a MultiTicket::Instance
+    end
+
+    it 'stores an instance of each ticket type' do
+      expect(subject.tickets.size).to eq 2
+      expect(subject.tickets.first).to be_a ServiceFeedback
+      expect(subject.tickets.last).to be_an AssistedDigitalHelpWithFeesFeedback
+    end
+
+    it 'supplies all the data to each ticket instance' do
+      service_ticket = subject.tickets.first
+
+      expect(service_ticket.service_satisfaction_rating).to eq('1')
+
+      assisted_digital_ticket = subject.tickets.last
+      expect(assisted_digital_ticket.service_satisfaction_rating).to eq('1')
+      expect(assisted_digital_ticket.assistance_received).to eq('no')
+    end
+  end
+
+  describe MultiTicket::Instance do
+    subject { MultiTicket.new(ServiceFeedback, AssistedDigitalHelpWithFeesFeedback).new(data) }
+    let(:data) do
+      {
+        assistance_received: 'no',
+        service_satisfaction_rating: '1'
+      }
+    end
+    let(:service_ticket) { subject.tickets.first }
+    let(:assisted_digital_ticket) { subject.tickets.last }
+
+    context '.valid?' do
+      it 'is vaild if all the tickets are valid' do
+        allow(service_ticket).to receive(:valid?).and_return true
+        allow(assisted_digital_ticket).to receive(:valid?).and_return true
+
+        expect(subject).to be_valid
+      end
+
+      it 'is not vaild if one of the tickets not valid' do
+        allow(service_ticket).to receive(:valid?).and_return true
+        allow(assisted_digital_ticket).to receive(:valid?).and_return false
+
+        expect(subject).not_to be_valid
+
+        allow(service_ticket).to receive(:valid?).and_return false
+        allow(assisted_digital_ticket).to receive(:valid?).and_return true
+
+        expect(subject).not_to be_valid
+      end
+
+      it 'is not vaild if all of the tickets not valid' do
+        allow(service_ticket).to receive(:valid?).and_return false
+        allow(assisted_digital_ticket).to receive(:valid?).and_return false
+
+        expect(subject).not_to be_valid
+      end
+    end
+
+    context '.save' do
+      it 'it asks each ticket to save' do
+        expect(service_ticket).to receive(:save)
+        expect(assisted_digital_ticket).to receive(:save)
+
+        subject.save
+      end
+
+      it 'it does not continue to the next ticket and raises the error if one of the tickets errors out while saving' do
+        expect(service_ticket).to receive(:save).and_raise "Uh-oh"
+        expect(assisted_digital_ticket).not_to receive(:save)
+
+        expect { subject.save }.to raise_error(RuntimeError, "Uh-oh")
+      end
+    end
+
+    context '.spam?' do
+      it 'is spam if all the tickets are spam' do
+        allow(service_ticket).to receive(:spam?).and_return true
+        allow(assisted_digital_ticket).to receive(:spam?).and_return true
+
+        expect(subject).to be_spam
+      end
+
+      it 'is spam if one of the tickets spam' do
+        allow(service_ticket).to receive(:spam?).and_return true
+        allow(assisted_digital_ticket).to receive(:spam?).and_return false
+
+        expect(subject).to be_spam
+
+        allow(service_ticket).to receive(:spam?).and_return false
+        allow(assisted_digital_ticket).to receive(:spam?).and_return true
+
+        expect(subject).to be_spam
+      end
+
+      it 'is not spam if none of the tickets are spam' do
+        allow(service_ticket).to receive(:spam?).and_return false
+        allow(assisted_digital_ticket).to receive(:spam?).and_return false
+
+        expect(subject).not_to be_spam
+      end
+    end
+
+    context '.errors' do
+      it 'is empty if none of the tickets have any errors' do
+        allow(service_ticket).to receive(:errors).and_return ActiveModel::Errors.new(service_ticket)
+        allow(assisted_digital_ticket).to receive(:errors).and_return ActiveModel::Errors.new(assisted_digital_ticket)
+
+        expect(subject.errors).to be_empty
+      end
+
+      it 'is not empty if there are errors on any of the tickets have any errors' do
+        service_errors = ActiveModel::Errors.new(service_ticket)
+        service_errors.add(:improvement_comments, 'is too long')
+        allow(service_ticket).to receive(:errors).and_return service_errors
+        allow(assisted_digital_ticket).to receive(:errors).and_return ActiveModel::Errors.new(assisted_digital_ticket)
+
+        expect(subject.errors).not_to be_empty
+
+        allow(service_ticket).to receive(:errors).and_return ActiveModel::Errors.new(service_ticket)
+
+        assisted_digital_errors = ActiveModel::Errors.new(assisted_digital_ticket)
+        assisted_digital_errors.add(:improvement_comments, 'is too long')
+        allow(assisted_digital_ticket).to receive(:errors).and_return assisted_digital_errors
+
+        expect(subject.errors).not_to be_empty
+      end
+
+      it 'collects all the errors from each ticket and re-presents them as one' do
+        service_errors = ActiveModel::Errors.new(service_ticket)
+        service_errors.add(:improvement_comments, 'is too long')
+        service_errors.add(:service_satisfaction_rating, 'is invalid')
+        allow(service_ticket).to receive(:errors).and_return service_errors
+
+        assisted_digital_errors = ActiveModel::Errors.new(assisted_digital_ticket)
+        assisted_digital_errors.add(:improvement_comments, 'is not long enough')
+        assisted_digital_errors.add(:assistance_received, 'is invalid')
+        allow(assisted_digital_ticket).to receive(:errors).and_return assisted_digital_errors
+
+        expect(subject.errors[:improvement_comments]).to eq ['is too long', 'is not long enough']
+        expect(subject.errors[:service_satisfaction_rating]).to eq ['is invalid']
+        expect(subject.errors[:assistance_received]).to eq ['is invalid']
+      end
+    end
+  end
+end

--- a/spec/requests/assisted_digital_help_with_fees_spec.rb
+++ b/spec/requests/assisted_digital_help_with_fees_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     submit_service_feedback
 
     expect(a_request(:post, %r{https://sheets.googleapis.com/v4/spreadsheets/*}).with { |request|
-      JSON.parse(request.body)["values"][0][2] == "it was fine"
+      JSON.parse(request.body)["values"][0][7] == "it was fine"
     }).to have_been_requested
   end
 
@@ -38,7 +38,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     submit_service_feedback(headers: { "HTTP_USER_AGENT" => "Shamfari/3.14159 (Fooey)" })
 
     expect(a_request(:post, %r{https://sheets.googleapis.com/v4/spreadsheets/*}).with { |request|
-      JSON.parse(request.body)["values"][0][4] == "Shamfari/3.14159 (Fooey)"
+      JSON.parse(request.body)["values"][0][9] == "Shamfari/3.14159 (Fooey)"
     }).to have_been_requested
   end
 
@@ -58,7 +58,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
   def valid_params
     {
       service_feedback: {
-        assistance: 'no',
+        assistance_received: 'no',
         service_satisfaction_rating: '5',
         improvement_comments: 'it was fine',
         slug: "some-transaction",


### PR DESCRIPTION
For: https://trello.com/c/kZCX6dGB/53-gov-uk-survey-assisted-digital-support-on-done-page

After feedback on the original version we needed to add new fields to the survey and send the standard satisfaction rating + comments to the same place as other service feedback so that we don't lose it in the performance platform.

This goes hand in hand with https://github.com/alphagov/frontend/pull/1035 which provides the frontend form.