### PR TITLE
Rename AssistedDigitalHelpWithFeesFeedback to remove HelpWithFees

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ In order to raise tickets in Zendesk, the `feedback` app submits data to the `su
 
         development> GDS_SSO_STRATEGY=real bowl signon support feedback
 
-### Assisted Digital Help With Fees Feedback
+### Assisted Digital Feedback
 
-This feedback is not stored in the support-api like the other tickets.  This data
-is stored in a google spreadsheet.  The ID of the spreadsheet to store the data
-in is set via the following environment:
+Assisted Digital feedback is stored twice.  The standard service feedback
+component is sent to support-api like other tickets, but the rest of the
+feedback specifically about assisted digital support is stored in a google
+spreadsheet.  The ID of the spreadsheet to store the data in is set via the
+following environment variable:
 
-    ASSISTED_DIGITAL_HELP_WITH_FEES_GOOGLE_SPREADSHEET_KEY
+    ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY
 
 To find the ID of a spreadsheet you wish to use, the [following documentation
 from google is useful](https://developers.google.com/sheets/guides/concepts#spreadsheet_id).

--- a/app/controllers/contact/govuk/assisted_digital_feedback_controller.rb
+++ b/app/controllers/contact/govuk/assisted_digital_feedback_controller.rb
@@ -1,16 +1,16 @@
 module Contact
   module Govuk
-    class AssistedDigitalHelpWithFeesFeedbackController < ContactController
+    class AssistedDigitalFeedbackController < ContactController
       rescue_from GoogleSpreadsheetStore::Error, with: :unable_to_create_ticket_error
 
     private
 
       def ticket_class
-        MultiTicket.new(AssistedDigitalHelpWithFeesFeedback, ServiceFeedback)
+        MultiTicket.new(AssistedDigitalFeedback, ServiceFeedback)
       end
 
       def type
-        :assisted_digital_help_with_fees_feedback
+        :assisted_digital_feedback
       end
 
       def contact_params

--- a/app/models/assisted_digital_feedback.rb
+++ b/app/models/assisted_digital_feedback.rb
@@ -1,6 +1,6 @@
 require 'uri'
 
-class AssistedDigitalHelpWithFeesFeedback < Ticket
+class AssistedDigitalFeedback < Ticket
   attr_accessor :assistance_received,
                 :assistance_received_comments,
                 :assistance_provided_by,
@@ -64,7 +64,7 @@ class AssistedDigitalHelpWithFeesFeedback < Ticket
   end
 
   def save
-    Feedback.assisted_digital_help_with_fees_spreadsheet.store(as_row_data) if valid?
+    Feedback.assisted_digital_spreadsheet.store(as_row_data) if valid?
   end
 
   def as_row_data

--- a/config/initializers/assisted_digital_feedback.rb
+++ b/config/initializers/assisted_digital_feedback.rb
@@ -1,0 +1,5 @@
+require 'google_spreadsheet_store'
+
+key = ENV['ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY']
+Feedback.assisted_digital_spreadsheet = GoogleSpreadsheetStore.new(key)
+

--- a/config/initializers/assisted_digital_help_with_fees_feedback.rb
+++ b/config/initializers/assisted_digital_help_with_fees_feedback.rb
@@ -1,5 +1,0 @@
-require 'google_spreadsheet_store'
-
-key = ENV['ASSISTED_DIGITAL_HELP_WITH_FEES_GOOGLE_SPREADSHEET_KEY']
-Feedback.assisted_digital_help_with_fees_spreadsheet = GoogleSpreadsheetStore.new(key)
-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Feedback::Application.routes.draw do
     namespace :govuk do
       post 'problem_reports', to: "problem_reports#create", format: false
       post 'service-feedback', to: "service_feedback#create", format: false
-      post 'assisted-digital-help-with-fees-survey-feedback', to: "assisted_digital_help_with_fees_feedback#create", format: false
+      post 'assisted-digital-survey-feedback', to: "assisted_digital_feedback#create", format: false
       post 'email-survey-signup', to: 'email_survey_signup#create', format: false
       post 'email-survey-signup.js', to: 'email_survey_signup#create', defaults: { format: :js }
       resources 'page_improvements', only: [:create], format: false

--- a/lib/feedback.rb
+++ b/lib/feedback.rb
@@ -1,6 +1,6 @@
 module Feedback
   mattr_accessor :support
   mattr_accessor :support_api
-  mattr_accessor :assisted_digital_help_with_fees_spreadsheet
+  mattr_accessor :assisted_digital_spreadsheet
   mattr_accessor :survey_notify_service
 end

--- a/spec/models/assisted_digital_feedback_spec.rb
+++ b/spec/models/assisted_digital_feedback_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
+RSpec.describe AssistedDigitalFeedback, type: :model do
   include ValidatorHelper
   include ActiveSupport::Testing::TimeHelpers
 
@@ -21,12 +21,12 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
 
     context '#save' do
       it 'sends the item to be stored in the google spreadsheet as row data' do
-        expect(Feedback.assisted_digital_help_with_fees_spreadsheet).to receive(:store).with(subject.as_row_data)
+        expect(Feedback.assisted_digital_spreadsheet).to receive(:store).with(subject.as_row_data)
         subject.save
       end
 
       it "should raise an exception if the google spreadsheet communication doesn't work" do
-        allow(Feedback.assisted_digital_help_with_fees_spreadsheet).to receive(:store).and_raise(GoogleSpreadsheetStore::Error.new('uh-oh!'))
+        allow(Feedback.assisted_digital_spreadsheet).to receive(:store).and_raise(GoogleSpreadsheetStore::Error.new('uh-oh!'))
         expect { subject.save }.to raise_error(GoogleSpreadsheetStore::Error, 'uh-oh!')
       end
     end
@@ -37,7 +37,7 @@ RSpec.describe AssistedDigitalHelpWithFeesFeedback, type: :model do
 
     context '#save' do
       it 'does not send the options to be stored in the google spreadsheet' do
-        expect(Feedback.assisted_digital_help_with_fees_spreadsheet).not_to receive(:store)
+        expect(Feedback.assisted_digital_spreadsheet).not_to receive(:store)
         subject.save
       end
     end

--- a/spec/models/multi_ticket_spec.rb
+++ b/spec/models/multi_ticket_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
 RSpec.describe MultiTicket, type: :model do
-  subject { described_class.new(ServiceFeedback, AssistedDigitalHelpWithFeesFeedback) }
+  subject { described_class.new(ServiceFeedback, AssistedDigitalFeedback) }
 
   context '#new' do
     it 'stores the supplied ticket types' do
-      expect(subject.ticket_types).to eq [ServiceFeedback, AssistedDigitalHelpWithFeesFeedback]
+      expect(subject.ticket_types).to eq [ServiceFeedback, AssistedDigitalFeedback]
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe MultiTicket, type: :model do
     it 'stores an instance of each ticket type' do
       expect(subject.tickets.size).to eq 2
       expect(subject.tickets.first).to be_a ServiceFeedback
-      expect(subject.tickets.last).to be_an AssistedDigitalHelpWithFeesFeedback
+      expect(subject.tickets.last).to be_an AssistedDigitalFeedback
     end
 
     it 'supplies all the data to each ticket instance' do
@@ -34,7 +34,7 @@ RSpec.describe MultiTicket, type: :model do
   end
 
   describe MultiTicket::Instance do
-    subject { MultiTicket.new(ServiceFeedback, AssistedDigitalHelpWithFeesFeedback).new(data) }
+    subject { MultiTicket.new(ServiceFeedback, AssistedDigitalFeedback).new(data) }
     let(:data) do
       {
         assistance_received: 'no',

--- a/spec/requests/assisted_digital_spec.rb
+++ b/spec/requests/assisted_digital_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
   end
 
   def submit_service_feedback(params: valid_params, headers: {})
-    post "/contact/govuk/assisted-digital-help-with-fees-survey-feedback", params, headers
+    post "/contact/govuk/assisted-digital-survey-feedback", params, headers
   end
 
   def valid_params


### PR DESCRIPTION
For: https://trello.com/c/kZCX6dGB/53-gov-uk-survey-assisted-digital-support-on-done-page

The survey is no longer just about help with fees and so we shouldn't
use that name in the routs, controllers, models, or environment variables
used to configure things.

Relies on:

* a puppet change to set the env var with the new name: https://github.com/alphagov/govuk-puppet/pull/5523
* a deployment change to set the values correctly with the name name: https://github.gds/gds/deployment/pull/1241