### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '~> 4.0'
 if ENV['SLIMMER_DEV']
   gem 'slimmer', path: '../slimmer'
 else
-  gem 'slimmer', '~> 10.0.0'
+  gem 'slimmer', '~> 10.1.1'
 end
 
 gem 'unicorn', '~> 4.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,7 @@ GEM
       faraday (~> 0.9)
       jwt (~> 1.5)
       multi_json (~> 1.10)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -318,7 +318,7 @@ DEPENDENCIES
   sass (~> 3.4.18)
   sass-rails (~> 5.0.4)
   shoulda-matchers (~> 2.8.0)
-  slimmer (~> 10.0.0)
+  slimmer (~> 10.1.1)
   statsd-ruby (~> 1.2.1)
   test-unit (= 3.1.3)
   uglifier (~> 2.7.2)

--- a/config/initializers/slimmer.rb
+++ b/config/initializers/slimmer.rb
@@ -1,8 +1,6 @@
 Feedback::Application.configure do
   config.slimmer.logger = Rails.logger
 
-  config.slimmer.use_cache = true if Rails.env.production?
-
   if Rails.env.development?
     config.slimmer.asset_host = ENV["STATIC_DEV"] || Plek.current.find('static')
   end


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will prevent this app from making many needless requests to `static`.

https://trello.com/c/D9HmkJwI