### PR TITLE
Add email survey signup routes and backend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ gem 'sass-rails', '~> 5.0.4'
 
 gem 'google-api-client', '~> 0.9'
 
+gem 'notifications-ruby-client'
+
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,8 @@ GEM
     netrc (0.11.0)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
+    notifications-ruby-client (2.0.0)
+      jwt (~> 1.5)
     null_logger (0.0.1)
     os (0.9.6)
     parser (2.3.1.4)
@@ -309,6 +311,7 @@ DEPENDENCIES
   govuk_frontend_toolkit (= 1.6.0)
   invalid_utf8_rejector
   logstasher (= 0.6.2)
+  notifications-ruby-client
   plek (~> 1.11.0)
   poltergeist (~> 1.6.0)
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -58,3 +58,40 @@ Authorisation for writing to the spreadsheet must be granted to the app.
 4.  Share the spreadsheet that you want to write data to with the email address
     stored in the `GOOGLE_CLIENT_EMAIL`.  It should have at least "can edit"
     permissions so the application can write data to the sheet.
+
+### Email Survey Signups
+
+This type of feedback is not actually feedback, it's a response from a banner
+displayed by static asking users to provide an email address where we can send
+them a link to a survey.  You can find out more about surveys in static [by
+reading the documentation](https://github.com/alphagov/static/blob/master/doc/surveys.md).
+
+The request will contain an `email_address` (the users email address), a
+`survey_source` (the path on GOV.UK where the sign up form was displayed), and
+`survey_id` (the survey they were invited to take part in).  The `survey_id`
+should match with an instance of `EmailSurvey` defined in [`app/models/email_survey.rb`.](app/models/email_survey.rb)
+These instances, like their counterparts in static, have start and endtimes so
+that we don't send emails when the survey has closed.  Unlike their counterparts
+in static they do not have match rules on the path - response that gets past an
+`survey_id` check and is in the `active?` time period will be sent an email.
+
+The email is sent using GOV.UK Notify using the "GOV.UK Surveys" service and a
+hardcoded email template (name: `email_survey_signup`, id: `8fe8ab4f-a6ac-44a1-9d8b-f611a493231b`)
+that belongs to that service.  This means that all running instances must use
+API keys for the same service or the template won't exist.  The API key is
+provided with the env var:
+
+    SURVEY_NOTIFY_SERVICE_API_KEY
+
+Deployed environments have this filled in via puppet and our standard mechanism
+for handling keys.  On the GOV.UK dev vm you'll want to join the service on
+GOV.UK Notify and create your own  API key.  When creating a key for yourself
+choosese either:
+
+* "test" - which won't send any emails at all, but will give you valid
+           responses from the API
+* "team" - which will only send emails to people on the team or the whitelisted
+           email addresses.
+
+Note that future versions may allow for different surveys to use different
+templates, but they'll still all have to belong to the same Notify service.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,10 +17,7 @@ protected
   end
 
   def unable_to_create_ticket_error(exception)
-    notify_airbrake(exception)
-
-    exception_class_name = exception.class.name.demodulize.downcase
-    Statsd.new(::STATSD_HOST).increment("#{::STATSD_PREFIX}.exception.#{exception_class_name}")
+    log_exception(exception)
 
     respond_to do |format|
       format.html do
@@ -39,5 +36,12 @@ protected
 
   def hide_report_a_problem_form_in_response
     response.headers[Slimmer::Headers::REPORT_A_PROBLEM_FORM] = "false"
+  end
+
+  def log_exception(exception)
+    notify_airbrake(exception)
+
+    exception_class_name = exception.class.name.demodulize.downcase
+    Statsd.new(::STATSD_HOST).increment("#{::STATSD_PREFIX}.exception.#{exception_class_name}")
   end
 end

--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -1,0 +1,48 @@
+module Contact
+  module Govuk
+    class EmailSurveySignupController < ContactController
+      rescue_from SurveyNotifyService::Error, with: :respond_to_notify_error
+
+      def ticket_class
+        EmailSurveySignup
+      end
+
+      def type
+        :email_survey_signup
+      end
+
+      def contact_params
+        params[:email_survey_signup] || {}
+      end
+
+      def confirm_submission
+        if request.xhr?
+          render json: { message: "email survey sign up success" }, status: :ok
+        else
+          redirect_to contact_anonymous_feedback_thankyou_path
+        end
+      end
+
+      def respond_to_invalid_submission(ticket)
+        if request.xhr?
+          render json: { message: "email survey sign up failure", errors: ticket.errors }, status: :unprocessable_entity
+        else
+          # for now, ignore just discard invalid submissions
+          # because the actual form lives in the "frontend" app,
+          # it's not straightforward to re-render the form with
+          # the user's original input
+          confirm_submission
+        end
+      end
+
+      def respond_to_notify_error(exception)
+        if request.xhr?
+          log_exception(exception)
+          render json: { message: "email survey sign up failure", errors: exception.cause.message }, status: :service_unavailable
+        else
+          unable_to_create_ticket_error(exception)
+        end
+      end
+    end
+  end
+end

--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -1,0 +1,32 @@
+class EmailSurvey
+  attr_accessor :id, :url, :start_time, :end_time
+  def initialize(id:, url:, start_time:, end_time:)
+    self.id = id
+    self.url = url
+    self.start_time = start_time
+    self.end_time = end_time
+  end
+
+  def active?(at: Time.zone.now)
+    at.between? start_time, end_time
+  end
+
+  def self.all
+    SURVEYS.values
+  end
+
+  def self.find(id)
+    SURVEYS.fetch(id)
+  end
+
+  SURVEYS = Hash[
+    [
+      new(
+        id: 'education_email_survey',
+        url: 'https://smartsurvey.co.uk.example.com/survey/1234',
+        start_time: Time.zone.parse("2017-02-23").beginning_of_day,
+        end_time: Time.zone.parse("2017-03-05").end_of_day,
+      ).freeze,
+    ].map { |s| [s.id, s] }
+  ].freeze
+end

--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -25,9 +25,9 @@ class EmailSurvey
     [
       new(
         id: 'education_email_survey',
-        url: 'https://smartsurvey.co.uk.example.com/survey/1234',
-        start_time: Time.zone.parse("2017-02-23").beginning_of_day,
-        end_time: Time.zone.parse("2017-03-05").end_of_day,
+        url: 'https://www.smartsurvey.co.uk/s/gov-uk/',
+        start_time: Time.zone.parse("2017-03-06").beginning_of_day,
+        end_time: Time.zone.parse("2017-03-10").end_of_day,
         name: 'education user research'
       ).freeze,
     ].map { |s| [s.id, s] }

--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -1,10 +1,11 @@
 class EmailSurvey
-  attr_accessor :id, :url, :start_time, :end_time
-  def initialize(id:, url:, start_time:, end_time:)
+  attr_accessor :id, :url, :start_time, :end_time, :name
+  def initialize(id:, url:, start_time:, end_time:, name:nil)
     self.id = id
     self.url = url
     self.start_time = start_time
     self.end_time = end_time
+    self.name = name.present? ? name : id.humanize
   end
 
   def active?(at: Time.zone.now)
@@ -26,6 +27,7 @@ class EmailSurvey
         url: 'https://smartsurvey.co.uk.example.com/survey/1234',
         start_time: Time.zone.parse("2017-02-23").beginning_of_day,
         end_time: Time.zone.parse("2017-03-05").end_of_day,
+        name: 'education user research'
       ).freeze,
     ].map { |s| [s.id, s] }
   ].freeze

--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -1,4 +1,5 @@
 class EmailSurvey
+  class NotFoundError < StandardError; end
   attr_accessor :id, :url, :start_time, :end_time, :name
   def initialize(id:, url:, start_time:, end_time:, name:nil)
     self.id = id
@@ -17,7 +18,7 @@ class EmailSurvey
   end
 
   def self.find(id)
-    SURVEYS.fetch(id)
+    SURVEYS.fetch(id) { |not_found_id| raise NotFoundError.new(not_found_id) }
   end
 
   SURVEYS = Hash[

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -15,11 +15,14 @@ class EmailSurveySignup
     attributes.each do |key, value|
       send("#{key}=", value) if respond_to? "#{key}="
     end
-    valid?
   end
 
   def spam?
     false
+  end
+
+  def save
+    Feedback.survey_notify_service.send_email(self) if valid?
   end
 
   def survey_source

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -26,8 +26,36 @@ class EmailSurveySignup
     UrlNormaliser.url_if_valid(@survey_source)
   end
 
+  def survey_name
+    survey.name if survey.present?
+  end
+
+  def survey_url
+    return nil unless survey.present?
+    uri = URI.parse(survey.url)
+    query_string = "c=#{CGI.escape(survey_source)}"
+    query_string.prepend("#{uri.query}&") unless uri.query.blank?
+    uri.query = query_string
+    uri.to_s
+  end
+
   def survey
     @survey ||= EmailSurvey.find(survey_id)
+  end
+
+  def to_notify_params
+    {
+      # this is our default template for emails, a future version might
+      # want to make this configurable per survey, but then we'd almost
+      # certainly need to make the `personalisation` parts configurable too
+      template_id: '8fe8ab4f-a6ac-44a1-9d8b-f611a493231b',
+      email_address: email_address,
+      personalisation: {
+        survey_name: survey_name,
+        survey_url: survey_url
+      },
+      reference: "email-survey-signup-#{object_id}"
+    }
   end
 
 private

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -41,6 +41,8 @@ class EmailSurveySignup
 
   def survey
     @survey ||= EmailSurvey.find(survey_id)
+  rescue EmailSurvey::NotFoundError
+    nil
   end
 
   def to_notify_params

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -1,0 +1,38 @@
+class EmailSurveySignup
+  include ActiveModel::Validations
+  attr_accessor :survey_id, :survey_source, :email_address
+
+  validates :email_address, presence: true,
+                            email: { message: "The email address must be valid" },
+                            length: { maximum: 1250 }
+  validates :survey_source, presence: true,
+                            length: { maximum: 2048 }
+  validates :survey_id, presence: true,
+                        inclusion: { in: ->(_instance) { EmailSurvey.all.map(&:id) } }
+  validate :survey_is_active, if: :survey
+
+  def initialize(attributes = {})
+    attributes.each do |key, value|
+      send("#{key}=", value) if respond_to? "#{key}="
+    end
+    valid?
+  end
+
+  def spam?
+    false
+  end
+
+  def survey_source
+    UrlNormaliser.url_if_valid(@survey_source)
+  end
+
+  def survey
+    @survey ||= EmailSurvey.find(survey_id)
+  end
+
+private
+
+  def survey_is_active
+    errors.add(:survey_id, :is_not_currently_running) unless survey.active?
+  end
+end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -26,7 +26,7 @@ class Ticket
   end
 
   def url
-    url_if_valid(@url)
+    UrlNormaliser.url_if_valid(@url)
   end
 
   def path
@@ -38,7 +38,7 @@ class Ticket
   end
 
   def referrer
-    url_if_valid(@referrer)
+    UrlNormaliser.url_if_valid(@referrer)
   end
 
 private
@@ -46,18 +46,5 @@ private
   def validate_val
     # val is used as a naive bot-preventor
     @errors.add :val unless val.blank?
-  end
-
-  def valid_url?(candidate)
-    url = URI.parse(candidate) rescue false
-    url.is_a?(URI::Generic) && (url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS) || url.relative?)
-  end
-
-  def url_if_valid(candidate)
-    case
-    when !valid_url?(candidate) then nil
-    when URI.parse(candidate).relative? then Plek.new.website_root + candidate
-    else candidate
-    end
   end
 end

--- a/config/initializers/survey_notify_service.rb
+++ b/config/initializers/survey_notify_service.rb
@@ -1,5 +1,12 @@
 require 'survey_notify_service'
 
-api_key = ENV['SURVEY_NOTIFY_SERVICE_API_KEY']
+api_key = if Rails.env.test?
+  # This is not a valid key, but it has the right form so the client
+  # won't break when interrogating it
+  'testkey1-12345678-90ab-cdef-1234-567890abcdef-12345678-90ab-cdef-1234-567890abcdef'
+else
+  ENV['SURVEY_NOTIFY_SERVICE_API_KEY']
+end
+
 Feedback.survey_notify_service = SurveyNotifyService.new(api_key)
 

--- a/config/initializers/survey_notify_service.rb
+++ b/config/initializers/survey_notify_service.rb
@@ -1,0 +1,5 @@
+require 'survey_notify_service'
+
+api_key = ENV['SURVEY_NOTIFY_SERVICE_API_KEY']
+Feedback.survey_notify_service = SurveyNotifyService.new(api_key)
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Feedback::Application.routes.draw do
       post 'problem_reports', to: "problem_reports#create", format: false
       post 'service-feedback', to: "service_feedback#create", format: false
       post 'assisted-digital-help-with-fees-survey-feedback', to: "assisted_digital_help_with_fees_feedback#create", format: false
+      post 'email-survey-signup', to: 'email_survey_signup#create', format: false
       resources 'page_improvements', only: [:create], format: false
     end
 

--- a/lib/feedback.rb
+++ b/lib/feedback.rb
@@ -2,4 +2,5 @@ module Feedback
   mattr_accessor :support
   mattr_accessor :support_api
   mattr_accessor :assisted_digital_help_with_fees_spreadsheet
+  mattr_accessor :survey_notify_service
 end

--- a/lib/survey_notify_service.rb
+++ b/lib/survey_notify_service.rb
@@ -1,0 +1,28 @@
+require 'notifications/client'
+require 'notifications/client/response_notification'
+
+class SurveyNotifyService
+  class Error < StandardError
+    attr_reader :cause
+    def initialize(message, cause = nil)
+      super(message)
+      @cause = cause
+    end
+  end
+
+  def initialize(api_key)
+    @api_key = api_key
+  end
+
+  def send_email(survey_signup)
+    client.send_email(survey_signup.to_notify_params)
+  rescue Notifications::Client::RequestError => e
+    raise Error.new("Communication with notify service failed", e)
+  end
+
+private
+
+  def client
+    @client ||= Notifications::Client.new(@api_key)
+  end
+end

--- a/lib/url_normaliser.rb
+++ b/lib/url_normaliser.rb
@@ -1,7 +1,11 @@
 module UrlNormaliser
-  def self.valid_url?(candidate)
+  def self.valid_url?(candidate, relative_only: false)
     url = URI.parse(candidate) rescue false
-    url.is_a?(URI::Generic) && (url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS) || url.relative?)
+    if relative_only
+      url.is_a?(URI::Generic) && url.relative? && candidate.starts_with?('/')
+    else
+      url.is_a?(URI::Generic) && (url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS) || url.relative?)
+    end
   end
 
   def self.url_if_valid(candidate)
@@ -10,5 +14,10 @@ module UrlNormaliser
     when URI.parse(candidate).relative? then Plek.new.website_root + candidate
     else candidate
     end
+  end
+
+  def self.relative_to_website_root(candidate)
+    return if candidate.nil?
+    candidate.sub(/\A#{Regexp.escape(Plek.new.website_root)}/, '')
   end
 end

--- a/lib/url_normaliser.rb
+++ b/lib/url_normaliser.rb
@@ -1,0 +1,14 @@
+module UrlNormaliser
+  def self.valid_url?(candidate)
+    url = URI.parse(candidate) rescue false
+    url.is_a?(URI::Generic) && (url.is_a?(URI::HTTP) || url.is_a?(URI::HTTPS) || url.relative?)
+  end
+
+  def self.url_if_valid(candidate)
+    case
+    when !valid_url?(candidate) then nil
+    when URI.parse(candidate).relative? then Plek.new.website_root + candidate
+    else candidate
+    end
+  end
+end

--- a/spec/lib/survey_notify_service_spec.rb
+++ b/spec/lib/survey_notify_service_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+require 'survey_notify_service'
+
+RSpec.describe SurveyNotifyService do
+  let(:education_email_survey) {
+    EmailSurvey.new(
+      id: 'education_email_survey',
+      url: 'http://survey.example.com/1',
+      start_time: 1.day.ago,
+      end_time: 2.days.from_now,
+      name: 'My name is: Education survey'
+    )
+  }
+  let(:all_surveys) { { education_email_survey.id => education_email_survey } }
+  before do
+    stub_const('EmailSurvey::SURVEYS', all_surveys)
+  end
+  let(:email_survey_signup) do
+    EmailSurveySignup.new(
+      survey_id: 'education_email_survey',
+      survey_source: 'https://www.gov.uk/done/some-transaction',
+      email_address: 'i_like_taking_surveys@example.com'
+    )
+  end
+
+  before do
+    stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email")
+      .to_return(status: 200, body: '{}')
+  end
+
+  context '#send_email' do
+    # This is not a valid key, but it has the right form
+    let(:api_key) { 'testkey1-12345678-90ab-cdef-1234-567890abcdef-12345678-90ab-cdef-1234-567890abcdef' }
+    subject { described_class.new(api_key) }
+
+    it 'sends the survey signup to notify' do
+      send_email_request = a_request(:post,
+        'https://api.notifications.service.gov.uk/v2/notifications/email'
+      ).with(body: email_survey_signup.to_notify_params.to_json)
+
+      subject.send_email(email_survey_signup)
+
+      expect(send_email_request).to have_been_requested
+    end
+
+    it 'wraps any errors from the notify API' do
+      stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email")
+        .to_return(status: 403, body: '{"errors":[{"error":"Forbidden","message":"You are not allowed to do this"}]}')
+      expect {
+        subject.send_email(email_survey_signup)
+      }.to raise_error { |error|
+        expect(error).to be_a described_class::Error
+        expect(error.message).to match(/Communication with notify service failed/)
+        expect(error.cause).to be_a Notifications::Client::RequestError
+        expect(error.cause.code).to eq '403'
+        expect(error.cause.message).to eq [{"error" => "Forbidden", "message" => "You are not allowed to do this"}]
+      }
+    end
+  end
+end

--- a/spec/lib/survey_notify_service_spec.rb
+++ b/spec/lib/survey_notify_service_spec.rb
@@ -2,18 +2,11 @@ require 'rails_helper'
 require 'survey_notify_service'
 
 RSpec.describe SurveyNotifyService do
-  let(:education_email_survey) {
-    EmailSurvey.new(
-      id: 'education_email_survey',
-      url: 'http://survey.example.com/1',
-      start_time: 1.day.ago,
-      end_time: 2.days.from_now,
-      name: 'My name is: Education survey'
-    )
-  }
-  let(:all_surveys) { { education_email_survey.id => education_email_survey } }
+  include EmailSurveyHelpers
+
+  let(:education_email_survey) { create_education_email_survey }
   before do
-    stub_const('EmailSurvey::SURVEYS', all_surveys)
+    stub_surveys_data education_email_survey
   end
   let(:email_survey_signup) do
     EmailSurveySignup.new(

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe EmailSurveySignup, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
+  let(:education_email_survey) {
+    EmailSurvey.new(
+      id: 'education_email_survey',
+      url: 'http://survey.example.com/1',
+      start_time: 1.day.ago,
+      end_time: 2.days.from_now
+    )
+  }
+  let(:all_surveys) { { education_email_survey.id => education_email_survey } }
+  before do
+    stub_const('EmailSurvey::SURVEYS', all_surveys)
+  end
+
+  subject { described_class.new(survey_options) }
+  let(:survey_options) do
+    {
+      survey_id: 'education_email_survey',
+      survey_source: 'https://www.gov.uk/done/some-transaction',
+      email_address: 'i_like_taking_surveys@example.com'
+    }
+  end
+
+  context "a minimal valid email survey signup item" do
+    it { is_expected.to be_valid }
+  end
+
+  context 'validations' do
+    it { is_expected.not_to allow_value(nil).for(:survey_id) }
+    it { is_expected.to validate_inclusion_of(:survey_id).in_array(EmailSurvey.all.map(&:id)) }
+    it 'is invalid if the survey_id refers to a survey that has not started yet' do
+      the_past = education_email_survey.start_time - 1.minute
+      travel_to(the_past) do
+        expect(subject).not_to be_valid
+      end
+    end
+    it 'is valid if the survey_id refers to a survey that has started and has not expired' do
+      the_now = education_email_survey.end_time - 1.minute
+      travel_to(the_now) do
+        expect(subject).to be_valid
+      end
+    end
+    it 'is invalid if the survey_id refers to a sruvey that has expired' do
+      the_future = education_email_survey.end_time + 1.minute
+      travel_to(the_future) do
+        expect(subject).not_to be_valid
+      end
+    end
+
+    it { is_expected.not_to allow_value(nil).for(:survey_source) }
+    it 'ensures `survey_source` has a length of at most 2048' do
+      # at the boundary it's ok
+      subject.survey_source = 'https://www.gov.uk/' + ('a' * 2029)
+      subject.valid?
+      expect(subject.errors[:survey_source]).not_to include "is too long (maximum is 2048 characters)"
+
+      # one char over and it errors
+      subject.survey_source += 'a'
+      subject.valid?
+      expect(subject.errors[:survey_source]).to include "is too long (maximum is 2048 characters)"
+    end
+    it "filters 'survey_source' to either nil or a valid URL" do
+      subject.survey_source = 'https://www.gov.uk'
+      expect(subject.survey_source).to eq('https://www.gov.uk')
+
+      subject.survey_source = "http://bla.example.org:9292/méh/fào?bar"
+      expect(subject.survey_source).to be_nil
+
+      subject.survey_source = nil
+      expect(subject.survey_source).to be_nil
+    end
+    it "adds the website root to relative sources" do
+      subject.survey_source = '/relative/url'
+      expect(subject.survey_source).to eq("#{Plek.new.website_root}/relative/url")
+    end
+
+    it { is_expected.not_to allow_value(nil).for(:email_address) }
+    it { is_expected.not_to allow_value("this15n0+A|\\|email").for(:email_address) }
+    it { is_expected.not_to allow_value("abc @d.com").for(:email_address) }
+    it { is_expected.not_to allow_value("abc@d.com.").for(:email_address) }
+    it { is_expected.to validate_length_of(:email_address).is_at_most(1250) }
+  end
+
+  context "#spam?" do
+    it 'is not spam' do
+      expect(subject).not_to be_spam
+    end
+  end
+end

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -2,19 +2,11 @@ require 'rails_helper'
 
 RSpec.describe EmailSurveySignup, type: :model do
   include ActiveSupport::Testing::TimeHelpers
+  include EmailSurveyHelpers
 
-  let(:education_email_survey) {
-    EmailSurvey.new(
-      id: 'education_email_survey',
-      url: 'http://survey.example.com/1',
-      start_time: 1.day.ago,
-      end_time: 2.days.from_now,
-      name: 'My name is: Education survey'
-    )
-  }
-  let(:all_surveys) { { education_email_survey.id => education_email_survey } }
+  let(:education_email_survey) { create_education_email_survey }
   before do
-    stub_const('EmailSurvey::SURVEYS', all_surveys)
+    stub_surveys_data(education_email_survey)
   end
 
   subject(:email_survey_signup) { described_class.new(survey_options) }

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -28,6 +28,29 @@ RSpec.describe EmailSurveySignup, type: :model do
 
   context "a minimal valid email survey signup item" do
     it { is_expected.to be_valid }
+
+    context '#save' do
+      it 'sends an email to the email address using GOV.UK notify' do
+        expect(Feedback.survey_notify_service).to receive(:send_email).with(subject)
+        subject.save
+      end
+
+      it "should raise an exception if the GOV.UK notify call doesn't work" do
+        allow(Feedback.survey_notify_service).to receive(:send_email).and_raise(SurveyNotifyService::Error.new("uh-oh!"))
+        expect { subject.save }.to raise_error(SurveyNotifyService::Error, "uh-oh!")
+      end
+    end
+  end
+
+  context 'an invalid feedback item' do
+    let(:survey_options) { {} }
+
+    context '#save' do
+      it 'does not send an email using GOV.UK notify' do
+        expect(Feedback.survey_notify_service).not_to receive(:send_email)
+        subject.save
+      end
+    end
   end
 
   context 'validations' do

--- a/spec/models/email_survey_spec.rb
+++ b/spec/models/email_survey_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe EmailSurvey, type: :model do
-  let(:subject) {
+  subject(:education_email_survey) {
     described_class.new(
       id: 'education_email_survey',
       url: 'https://smartsurvey.co.uk.example.com/survey/1234',

--- a/spec/models/email_survey_spec.rb
+++ b/spec/models/email_survey_spec.rb
@@ -1,17 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe EmailSurvey, type: :model do
-  subject(:education_email_survey) {
-    described_class.new(
-      id: 'education_email_survey',
-      url: 'https://smartsurvey.co.uk.example.com/survey/1234',
-      start_time: 1.day.ago,
-      end_time: 1.day.from_now,
-    )
-  }
-  let(:all_surveys) { { education_email_survey.id => education_email_survey } }
+  include EmailSurveyHelpers
+  subject(:education_email_survey) { create_education_email_survey }
   before do
-    stub_const('EmailSurvey::SURVEYS', all_surveys)
+    stub_surveys_data(education_email_survey)
   end
 
   describe '.find' do

--- a/spec/models/email_survey_spec.rb
+++ b/spec/models/email_survey_spec.rb
@@ -9,6 +9,23 @@ RSpec.describe EmailSurvey, type: :model do
       end_time: 1.day.from_now,
     )
   }
+  let(:all_surveys) { { education_email_survey.id => education_email_survey } }
+  before do
+    stub_const('EmailSurvey::SURVEYS', all_surveys)
+  end
+
+  describe '.find' do
+    subject { described_class }
+    it 'returns the survey with the supplied id' do
+      expect(subject.find('education_email_survey')).to eq education_email_survey
+    end
+
+    it 'raises a NotFoundError if the supplied id is not a real survey' do
+      expect {
+        subject.find('not-a-real-survey')
+      }.to raise_error(described_class::NotFoundError, 'not-a-real-survey')
+    end
+  end
 
   describe '#active?' do
     it 'is not active when the start_time is in the future' do

--- a/spec/models/email_survey_spec.rb
+++ b/spec/models/email_survey_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe EmailSurvey, type: :model do
+  let(:subject) {
+    described_class.new(
+      id: 'education_email_survey',
+      url: 'https://smartsurvey.co.uk.example.com/survey/1234',
+      start_time: 1.day.ago,
+      end_time: 1.day.from_now,
+    )
+  }
+
+  describe '#active?' do
+    it 'is not active when the start_time is in the future' do
+      expect(subject).not_to be_active(at: 2.days.ago)
+    end
+
+    it 'is not active when the end_time is in the past' do
+      expect(subject).not_to be_active(at: 2.days.from_now)
+    end
+
+    it 'is active on the start time' do
+      expect(subject).to be_active(at: subject.start_time)
+    end
+
+    it 'is active on the end time' do
+      expect(subject).to be_active(at: subject.end_time)
+    end
+
+    it 'is active between the start and end time' do
+      expect(subject).to be_active(at: subject.start_time + 1.second)
+      expect(subject).to be_active(at: subject.end_time - 1.second)
+    end
+  end
+end

--- a/spec/requests/email_survey_signup_request_spec.rb
+++ b/spec/requests/email_survey_signup_request_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+RSpec.describe "Email survey sign-up request", type: :request do
+  include EmailSurveyHelpers
+  before do
+    stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
+      .to_return(status: 200, body: '{}')
+
+    stub_surveys_data(create_education_email_survey)
+  end
+
+  context 'for a standard HTML request' do
+    it "shows the standard thank you message on success" do
+      submit_email_survey_sign_up
+
+      expect(response).to redirect_to(contact_anonymous_feedback_thankyou_path)
+      get contact_anonymous_feedback_thankyou_path
+
+      expect(response.body).to include("Thank you for your feedback.")
+    end
+
+    it "should accept invalid submissions, just not do anything with them (because the form itself lives
+      in the static app and re-rendering it with the user's signup isn't straightforward" do
+      submit_email_survey_sign_up(params: {})
+
+      expect(response).to redirect_to(contact_anonymous_feedback_thankyou_path)
+      get contact_anonymous_feedback_thankyou_path
+
+      expect(response.body).to include("Thank you for your feedback.")
+    end
+
+    it "should handle the GOV.UK notify service failing" do
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
+        .to_return(status: 403, body: '{"errors":[{"error":"forbidden","message":"You cannot do this!"}]}')
+
+      submit_email_survey_sign_up
+
+      # the user should see the standard GOV.UK 503 page
+      expect(response.code).to eq("503")
+    end
+  end
+
+  context 'for an AJAX request' do
+    it "responds inline with a 200 ok success message" do
+      submit_email_survey_sign_up as_xhr: true
+
+      expect(response).to have_http_status(:ok)
+      expect(response.content_type).to eq("application/json")
+      expect(JSON.parse(response.body)).to eq({ "message" => "email survey sign up success"})
+    end
+
+    it "responds with a 422 failure for invalid submissions" do
+      submit_email_survey_sign_up as_xhr: true, params: {}
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.content_type).to eq("application/json")
+      json_response = JSON.parse(response.body)
+      expect(json_response).to have_key "message"
+      expect(json_response["message"]).to eq "email survey sign up failure"
+      expect(json_response).to have_key "errors"
+    end
+
+    it "should handle the GOV.UK notify service failing" do
+      stub_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
+        .to_return(status: 403, body: '{"errors":[{"error":403,"message":"forbidden"}]}')
+
+      submit_email_survey_sign_up as_xhr: true
+
+      expect(response).to have_http_status(:service_unavailable)
+      expect(response.content_type).to eq("application/json")
+      json_response = JSON.parse(response.body)
+      expect(json_response).to have_key "message"
+      expect(json_response["message"]).to eq "email survey sign up failure"
+      expect(json_response).to have_key "errors"
+    end
+  end
+
+  it "sends an email to the supplied email address using GOV.UK notify" do
+    submit_email_survey_sign_up
+
+    notify_request = a_request(:post, 'https://api.notifications.service.gov.uk/v2/notifications/email')
+      .with { |request|
+        json_payload = JSON.parse(request.body)
+        (json_payload["email_address"] == "i_like_surveys@example.com") &&
+          (json_payload["personalisation"]["survey_name"] == "My name is: Education survey")
+      }
+    expect(notify_request).to have_been_requested
+  end
+
+  def submit_email_survey_sign_up(params: valid_params, headers: {}, as_xhr: false)
+    args = ["/contact/govuk/email-survey-signup", params, headers]
+    if as_xhr
+      xhr(:post, *args)
+    else
+      post *args
+    end
+  end
+
+  def valid_params
+    {
+      email_survey_signup: {
+        survey_id: 'education_email_survey',
+        survey_source: 'https://www.gov.uk/done/some-transaction',
+        email_address: "i_like_surveys@example.com",
+      }
+    }
+  end
+end

--- a/spec/requests/email_survey_signup_request_spec.rb
+++ b/spec/requests/email_survey_signup_request_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
     {
       email_survey_signup: {
         survey_id: 'education_email_survey',
-        survey_source: 'https://www.gov.uk/done/some-transaction',
+        survey_source: '/done/some-transaction',
         email_address: "i_like_surveys@example.com",
       }
     }

--- a/spec/support/email_survey_helpers.rb
+++ b/spec/support/email_survey_helpers.rb
@@ -1,0 +1,16 @@
+module EmailSurveyHelpers
+  def create_education_email_survey
+    EmailSurvey.new(
+      id: 'education_email_survey',
+      url: 'http://survey.example.com/1',
+      start_time: 1.day.ago,
+      end_time: 2.days.from_now,
+      name: 'My name is: Education survey'
+    )
+  end
+
+  def stub_surveys_data(*surveys)
+    surveys_data = surveys.each.with_object({}) { |s, data| data[s.id] = s }
+    stub_const('EmailSurvey::SURVEYS', surveys_data)
+  end
+end


### PR DESCRIPTION
For: https://trello.com/c/dfSufy85/114-develop-a-new-survey-delivery-method

This is the backend component that https://github.com/alphagov/static/pull/912 submits to.  We should review this in tandem.  There's duplication between static and feedback in that both will need details of the survey start/end times, but I think that's safe, otherwise people can sign up when we don't want them to.

Relies on a puppet PR (see: https://github.com/alphagov/govuk-puppet/pull/5574) and a deployment PR (see: https://github.gds/gds/deployment/pull/1249) to set up the api_keys as env vars.