### PR TITLE
Make email survey signup work on deployed env

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,24 @@ choosese either:
 
 Note that future versions may allow for different surveys to use different
 templates, but they'll still all have to belong to the same Notify service.
+
+#### A note on Notify template parameters
+
+Notify templates can be parameterised, and when we talk to the notify API we
+send a `personalisation` key that contains values for all the parameters in the
+template.  Notify will error if there are missing keys, but it will also error
+if there are extra keys.  This means we have to take care when editing the
+template in the Notify UI and take care not to introduce, nor remove parameters
+without updating the code.
+
+Currently the template takes a single parameter:
+
+* `survey_url` - the url that the survey lives at and will be sent in the email
+                 to invite the user to take part in that survey - this is
+                 constructed by taking the `url` of the `EmailSurvey` instance
+                 and adding the `survey_source` as a `c` param to the query
+                 string.
+
+Adding new parameters will require a deploy, so it might be best to add a new
+template with new parameters and have the deploy change the template id *and*
+the parameters.

--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -16,7 +16,7 @@ module Contact
       end
 
       def confirm_submission
-        if request.xhr?
+        if ajax_request?
           render json: { message: "email survey sign up success" }, status: :ok
         else
           redirect_to contact_anonymous_feedback_thankyou_path
@@ -24,7 +24,7 @@ module Contact
       end
 
       def respond_to_invalid_submission(ticket)
-        if request.xhr?
+        if ajax_request?
           render json: { message: "email survey sign up failure", errors: ticket.errors }, status: :unprocessable_entity
         else
           # for now, ignore just discard invalid submissions
@@ -36,12 +36,18 @@ module Contact
       end
 
       def respond_to_notify_error(exception)
-        if request.xhr?
+        if ajax_request?
           log_exception(exception)
           render json: { message: "email survey sign up failure", errors: exception.cause.message }, status: :service_unavailable
         else
           unable_to_create_ticket_error(exception)
         end
+      end
+
+    private
+
+      def ajax_request?
+        request.xhr? || request.format == :js
       end
     end
   end

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -57,7 +57,9 @@ class EmailSurveySignup
       template_id: '8fe8ab4f-a6ac-44a1-9d8b-f611a493231b',
       email_address: email_address,
       personalisation: {
-        survey_name: survey_name,
+        # Note that notify will error if we don't supply all the keys the
+        # template uses, but it will also error if we supply extra keys the
+        # template doesn't use.  Take care here.
         survey_url: survey_url
       },
       reference: "email-survey-signup-#{object_id}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Feedback::Application.routes.draw do
       post 'service-feedback', to: "service_feedback#create", format: false
       post 'assisted-digital-help-with-fees-survey-feedback', to: "assisted_digital_help_with_fees_feedback#create", format: false
       post 'email-survey-signup', to: 'email_survey_signup#create', format: false
+      post 'email-survey-signup.js', to: 'email_survey_signup#create', defaults: { format: :js }
       resources 'page_improvements', only: [:create], format: false
     end
 

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -165,8 +165,11 @@ RSpec.describe EmailSurveySignup, type: :model do
       expect(subject[:reference]).to eq "email-survey-signup-#{email_survey_signup.object_id}"
     end
 
-    it "includes the survey name in the personalisation details" do
-      expect(subject[:personalisation][:survey_name]).to eq 'My name is: Education survey'
+    it "only has survey_url as a key in the personalisation details" do
+      # Notify raises an error if you supply un-needed params in the
+      # personalisation hash and our template only uses survey_url currently
+      expect(subject[:personalisation].size).to eq 1
+      expect(subject[:personalisation]).to have_key(:survey_url)
     end
 
     it "includes the survey url in the personalisation details" do

--- a/spec/requests/email_survey_signup_request_spec.rb
+++ b/spec/requests/email_survey_signup_request_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
       .with { |request|
         json_payload = JSON.parse(request.body)
         (json_payload["email_address"] == "i_like_surveys@example.com") &&
-          (json_payload["personalisation"]["survey_name"] == "My name is: Education survey")
+          (json_payload["personalisation"]["survey_url"] == "http://survey.example.com/1?c=%2Fdone%2Fsome-transaction")
       }
     expect(notify_request).to have_been_requested
   end


### PR DESCRIPTION
Best reviewed as two commits:

1. we can't use `request.xhr?` as it seems our infrastructure strips off the `X-Requested-With` header that rails uses to answer `true` to that question - so we need to support responding to a `.js` version of the url (the static PR has been updated to submit to this .js version of the end point too - see https://github.com/alphagov/static/pull/912/commits/c573634a388eba1fd57901a611ce002b62d59812)
2. notify will break if you submit extra params as part of personalisation, not just if you submit without all the params.  our template only needs `survey_url` now, not `survey_name` as well so we need to make our code do that.

For: https://trello.com/c/dfSufy85/114-develop-a-new-survey-delivery-method