### PR TITLE
Set correct identifier and dates for first email survey

### DIFF
--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -24,11 +24,11 @@ class EmailSurvey
   SURVEYS = Hash[
     [
       new(
-        id: 'education_email_survey',
+        id: 'govuk_email_survey_t01',
         url: 'https://www.smartsurvey.co.uk/s/gov-uk/',
-        start_time: Time.zone.parse("2017-03-06").beginning_of_day,
-        end_time: Time.zone.parse("2017-03-10").end_of_day,
-        name: 'education user research'
+        start_time: Time.zone.parse("2017-03-08").beginning_of_day,
+        end_time: Time.zone.parse("2017-03-13").end_of_day,
+        name: 'GOV.UK user research'
       ).freeze,
     ].map { |s| [s.id, s] }
   ].freeze


### PR DESCRIPTION
The id needs to be `govuk_email_survey_t01` because the previous version,
`education_email_survey` implied it was about education when in fact it
was explicitly to exclude education.  We also change the dates to run from
the 8th to the 13th.  The frontend counterpart is actually 2 surveys; one
that runs from the 8th to 1pm on the 10th, and another that runs from 1pm
on the 10th to the end of the day on the 13th.  The only difference is the
frequency so our backend can treat them as the same survey.

For: https://trello.com/c/dfSufy85/114-develop-a-new-survey-delivery-method