### PR TITLE
Use separate survey definitions for the Thursday and Weekend surveys

### DIFF
--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -27,6 +27,13 @@ class EmailSurvey
         id: 'govuk_email_survey_t01',
         url: 'https://www.smartsurvey.co.uk/s/gov-uk/',
         start_time: Time.zone.parse("2017-03-08").beginning_of_day,
+        end_time: Time.zone.parse("2017-03-10").end_of_day,
+        name: 'GOV.UK user research'
+      ).freeze,
+      new(
+        id: 'govuk_email_survey_t02',
+        url: 'https://www.smartsurvey.co.uk/s/gov_uk/',
+        start_time: Time.zone.parse("2017-03-10").beginning_of_day,
         end_time: Time.zone.parse("2017-03-13").end_of_day,
         name: 'GOV.UK user research'
       ).freeze,


### PR DESCRIPTION
The user research team became concerned that they wouldn't be able to tell
which users were signing up to the survey via the 1-in-1 version running
on Thursday->Friday lunch and which were signing up via the 1-in-2 version
running from Friday lunch to Monday eve.  To that end we want different
identifiers (which will be used in events in the frontend) and different
survey urls.