### PR TITLE
Update gds-api-adapters gem to get the latest special route publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'notifications-ruby-client'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '36.3.0'
+  gem 'gds-api-adapters', '41.2.0'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (36.3.0)
+    gds-api-adapters (41.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -163,7 +163,7 @@ GEM
       byebug (~> 9.0)
       pry (~> 0.10)
     rack (1.6.4)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -304,7 +304,7 @@ DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.5.0)
   ci_reporter_rspec
-  gds-api-adapters (= 36.3.0)
+  gds-api-adapters (= 41.2.0)
   google-api-client (~> 0.9)
   govuk-content-schema-test-helpers
   govuk-lint
@@ -330,4 +330,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.10.6
+   1.14.5


### PR DESCRIPTION
Update the API adapter gem so that special route publishing contains the new fields added to the `special_route` schema.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing