### PR TITLE
Reverts previous commit

### DIFF
--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -25,9 +25,9 @@ class EmailSurvey
     [
       new(
         id: 'govuk_email_survey_t02',
-        url: 'https://www.smartsurvey.co.uk/s/_govuk/',
-        start_time: Time.zone.parse("2017-04-03").beginning_of_day,
-        end_time: Time.zone.parse("2017-04-04").end_of_day,
+        url: 'https://www.smartsurvey.co.uk/s/govuk-',
+        start_time: Time.zone.parse("2017-03-22").beginning_of_day,
+        end_time: Time.zone.parse("2017-03-24").end_of_day,
         name: 'GOV.UK user research'
       ).freeze,
     ].map { |s| [s.id, s] }


### PR DESCRIPTION
This will revert: https://github.com/alphagov/feedback/commit/9612d647045ef2711f50ccf0ca0932c9dd7067a1

Reason: There is currently an error when sending email surveys. It might be related to these changes so I am reverting them and testing the error separately. This is done to unblock static and feedback from being deployed to production.