### PR TITLE
Configure new email survey

### DIFF
--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -21,13 +21,16 @@ class EmailSurvey
     SURVEYS.fetch(id) { |not_found_id| raise NotFoundError.new(not_found_id) }
   end
 
+  # TODO: allow for surveys with no start/end time?
   SURVEYS = Hash[
     [
+      # This is the default survey that runs across the whole site
+      # hence the long lived start/end times
       new(
-        id: 'govuk_email_survey_t02',
-        url: 'https://www.smartsurvey.co.uk/s/_govuk',
-        start_time: Time.zone.parse("2017-04-03").beginning_of_day,
-        end_time: Time.zone.parse("2017-04-04").end_of_day,
+        id: 'user_satisfaction_survey',
+        url: 'https://www.smartsurvey.co.uk/s/gov-uk',
+        start_time: Time.zone.parse("2017-01-01").beginning_of_day,
+        end_time: Time.zone.parse("2116-12-31").end_of_day,
         name: 'GOV.UK user research'
       ).freeze,
     ].map { |s| [s.id, s] }


### PR DESCRIPTION
For: https://trello.com/c/m9pylftF/172-govuk-survey-configure-new-default-survey-using-email-type

This is the default survey for the whole site which is why we have such
a far-future end time.

Note: needs to be deployed before the corresponding PR on static (see: https://github.com/alphagov/static/pull/1070) that configures the new frontend survey UI to uses this backend survey definition.