### PR TITLE
Fix referrer value in ticket attributes

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -25,7 +25,7 @@ class ContactController < ApplicationController
   end
 
   def create
-    data = contact_params.merge(technical_attributes)
+    data = contact_params.merge(browser_attributes)
     ticket = ticket_class.new data
 
     if ticket.valid?
@@ -96,6 +96,15 @@ private
 
   def set_cache_control
     expires_in 10.minutes, public: true unless Rails.env.development?
+  end
+
+  def browser_attributes
+    technical_attributes.merge(referrer_attribute)
+  end
+
+  def referrer_attribute
+    referrer = request.referrer
+    referrer.present? ? { referrer: referrer } : {}
   end
 
   def technical_attributes

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -37,6 +37,16 @@ RSpec.describe "Service feedback submission", type: :request do
     end
   end
 
+  it "should include the referrer if available" do
+    stub_support_api_service_feedback_creation
+
+    submit_service_feedback
+
+    assert_requested(:post, %r{/service-feedback}) do |request|
+      JSON.parse(request.body)["service_feedback"]["referrer"] == "https://www.some-transaction.service.gov/uk/completed"
+    end
+  end
+
   it "should accept invalid submissions, just not do anything with them (because the form itself lives
     in the feedback app and re-rendering it with the user's original feedback isn't straightforward" do
     post "/contact/govuk/service-feedback", {}


### PR DESCRIPTION
[Trello card](https://trello.com/c/jRjwskxV)

When a ticket is created we are not receiving the referrer for a ServiceFeedback. We need to explicitly set it to ensure it’s coming through.

This has been causing issues where users are expecting to see the referrer in Feedback Explorer when viewing feedback for the service. But the referrer was not being recorded for the feedback.