### PR TITLE
Send update type with put content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'notifications-ruby-client'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '41.2.0'
+  gem 'gds-api-adapters', '47.2'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (41.2.0)
+    gds-api-adapters (47.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -304,7 +304,7 @@ DEPENDENCIES
   airbrake (~> 4.3.1)
   capybara (~> 2.5.0)
   ci_reporter_rspec
-  gds-api-adapters (= 41.2.0)
+  gds-api-adapters (= 47.2)
   google-api-client (~> 0.9)
   govuk-content-schema-test-helpers
   govuk-lint

--- a/lib/redirect_publisher.rb
+++ b/lib/redirect_publisher.rb
@@ -28,6 +28,6 @@ class RedirectPublisher
     }
 
     publishing_api.put_content(content_id, redirect)
-    publishing_api.publish(content_id, "major")
+    publishing_api.publish(content_id)
   end
 end

--- a/spec/lib/redirect_publisher_spec.rb
+++ b/spec/lib/redirect_publisher_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe RedirectPublisher do
     api = double(:publishing_api)
 
     expect(api).to receive(:put_content).with(content_id, expected_redirect)
-    expect(api).to receive(:publish).once.with(content_id, 'major')
+    expect(api).to receive(:publish).once.with(content_id)
 
     expect(logger).to receive(:info)
       .with("Registering redirect #{content_id}: '#{current_base_path}' -> '#{destination_path}'")
@@ -60,7 +60,7 @@ RSpec.describe RedirectPublisher do
 
     api = double(:publishing_api)
     expect(api).to receive(:put_content).with(an_instance_of(String), be_valid_against_schema('redirect'))
-    expect(api).to receive(:publish).once.with(content_id, 'major')
+    expect(api).to receive(:publish).once.with(content_id)
 
     expect(logger).to receive(:info)
       .with("Registering redirect #{content_id}: '#{current_base_path}' -> '#{destination_path}'")

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should let the user submit an anonymous request" do
-    stub_post = stub_support_long_form_anonymous_contact_creation(
+    stub_post = stub_support_api_long_form_anonymous_contact_creation(
       details: "test text details",
       link: nil,
       user_specified_url: nil,

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Page improvements", type: :request do
 
   it "responds successfully" do
     params = { description: "The title is the wrong colour." }
-    stub_create_page_improvement(params)
+    stub_support_api_create_page_improvement(params)
 
     post "/contact/govuk/page_improvements", params.to_json, common_headers
 


### PR DESCRIPTION
Sending it on publish has been deprecated in favour of including it when sending a put content.

[Trello Card](https://trello.com/c/LnJlkb9e/987-5-deprecate-the-usage-of-updatetype-in-publish-for-publishing-api-and-update-usage-across-govuk)