### PR TITLE
Add SRI attributes

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,9 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <%=  stylesheet_link_tag 'feedback' %>
+    <%=  stylesheet_link_tag 'feedback', integrity: true, crossorigin: 'anonymous' %>
     <!--[if IE 6]><%= stylesheet_link_tag "feedback-ie6.css" %><![endif]-->
-    <%=  javascript_include_tag 'feedback' %>
+    <%=  javascript_include_tag 'feedback', integrity: true, crossorigin: 'anonymous' %>
     <title><%= yield :title %></title>
     <%= yield :section_meta_tags %>
   </head>


### PR DESCRIPTION
For: https://trello.com/c/TwBLfagk/149-enable-subresource-integrity-sri-on-feedback-s

We ignore the IE6 stylesheet because IE6 doesn't support SRI at all so
it'd be pointless.  Most other assets included in production come from
static so can't be handled in this app.