### PR TITLE
Add BOM remover gem to fix SRI issues on firefox

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'uglifier', '~> 2.7.2'
 gem 'govuk_frontend_toolkit', '1.6.0'
 gem 'sass', '~> 3.4.18'
 gem 'sass-rails', '~> 5.0.4'
+gem 'asset_bom_removal-rails', '~> 1.0.0'
 
 gem 'google-api-client', '~> 0.9'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,9 @@ GEM
       builder
       multi_json
     arel (6.0.3)
+    asset_bom_removal-rails (1.0.0)
+      rails (>= 4.2)
+      sass (> 3.4)
     ast (2.3.0)
     builder (3.2.2)
     byebug (9.0.5)
@@ -302,6 +305,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.3.1)
+  asset_bom_removal-rails (~> 1.0.0)
   capybara (~> 2.5.0)
   ci_reporter_rspec
   gds-api-adapters (= 47.2)
@@ -330,4 +334,4 @@ DEPENDENCIES
   webmock (~> 1.21.0)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1


### PR DESCRIPTION
For: https://trello.com/c/TwBLfagk/149-enable-subresource-integrity-sri-on-feedback-s

This injects itself into the rails asset pipeline and makes sure that
the CSS we compress with sass does not include a BOM if it is a UTF-8
file. Firefox < 52 has a bug in how it calculates SRI hashes for CSS
files with a BOM and this gem mitigates that. One of the delivered CSS
assets is UTF-8 so we absolutely need to use this gem to avoid breaking
the feedback forms for users of older versions of firefox.

Should have added this to #208 but I forgot 😞 