### PR TITLE
Add GA client ID to email surveys

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ them a link to a survey.  You can find out more about surveys in static [by
 reading the documentation](https://github.com/alphagov/static/blob/master/doc/surveys.md).
 
 The request will contain an `email_address` (the users email address), a
-`survey_source` (the path on GOV.UK where the sign up form was displayed), and
+`survey_source` (the path on GOV.UK where the sign up form was displayed), 
+`ga_client_id` (the Google Analytics client ID for that user's session), and
 `survey_id` (the survey they were invited to take part in).  The `survey_id`
 should match with an instance of `EmailSurvey` defined in [`app/models/email_survey.rb`.](app/models/email_survey.rb)
 These instances, like their counterparts in static, have start and endtimes so
@@ -113,7 +114,9 @@ Currently the template takes a single parameter:
                  to invite the user to take part in that survey - this is
                  constructed by taking the `url` of the `EmailSurvey` instance
                  and adding the `survey_source` as a `c` param to the query
-                 string.
+                 string. At the end of the url we will also add the `ga_client_id`
+                 (e.g. if we have ga_client_id = '12345.67899' then the resulting 
+                 `survey_url` will be appended with `&gcl=12345.67890`)
 
 Adding new parameters will require a deploy, so it might be best to add a new
 template with new parameters and have the deploy change the template id *and*

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -1,6 +1,6 @@
 class EmailSurveySignup
   include ActiveModel::Validations
-  attr_accessor :survey_id, :survey_source, :email_address
+  attr_accessor :survey_id, :survey_source, :email_address, :ga_client_id
 
   validates :email_address, presence: true,
                             email: { message: "The email address must be valid" },
@@ -38,6 +38,7 @@ class EmailSurveySignup
     return nil unless survey.present?
     uri = URI.parse(survey.url)
     query_string = "c=#{CGI.escape(survey_source)}"
+    query_string += "&gcl=#{ga_client_id}" if ga_client_id.present?
     query_string.prepend("#{uri.query}&") unless uri.query.blank?
     uri.query = query_string
     uri.to_s

--- a/spec/lib/survey_notify_service_spec.rb
+++ b/spec/lib/survey_notify_service_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe SurveyNotifyService do
     EmailSurveySignup.new(
       survey_id: 'education_email_survey',
       survey_source: 'https://www.gov.uk/done/some-transaction',
-      email_address: 'i_like_taking_surveys@example.com'
+      email_address: 'i_like_taking_surveys@example.com',
+      ga_client_id: '12345.67890'
     )
   end
 


### PR DESCRIPTION
For: https://trello.com/c/xDdnial5/220-clientid-pushed-into-email-surveys-as-custom-data

In order to track the user journey when a user completes an EMAIL survey, we can use the client ID to identify a session for a user and record all the pages he has visited before arriving to our survey. This will provide a more detailed picture about our user's browsing habits and will help to separate the data out, since the info collected on surveys is anonymous.

Works in conjunction with: https://github.com/alphagov/static/pull/1126