### PR TITLE
Include referrer from posted params if present

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -103,7 +103,7 @@ private
   end
 
   def referrer_attribute
-    referrer = request.referrer
+    referrer = contact_params[:referrer] || params[:referrer] || request.referrer
     referrer.present? ? { referrer: referrer } : {}
   end
 

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -30,20 +30,60 @@ RSpec.describe "Service feedback submission", type: :request do
   it "should include the user_agent if available" do
     stub_support_api_service_feedback_creation
 
-    submit_service_feedback("HTTP_USER_AGENT" => "Shamfari/3.14159 (Fooey)")
+    submit_service_feedback(headers: { "HTTP_USER_AGENT" => "Shamfari/3.14159 (Fooey)" })
 
     assert_requested(:post, %r{/service-feedback}) do |request|
       JSON.parse(request.body)["service_feedback"]["user_agent"] == "Shamfari/3.14159 (Fooey)"
     end
   end
 
-  it "should include the referrer if available" do
-    stub_support_api_service_feedback_creation
+  context 'the referrer value' do
+    before do
+      stub_support_api_service_feedback_creation
+    end
 
-    submit_service_feedback
+    it "uses the value in the service_feedback params" do
+      posted_params = valid_params
+      posted_params[:service_feedback][:referrer] = 'http://referrer.example.com/i-came-from-here'
+      posted_params.delete(:referrer)
+      submit_service_feedback(params: posted_params)
 
-    assert_requested(:post, %r{/service-feedback}) do |request|
-      JSON.parse(request.body)["service_feedback"]["referrer"] == "https://www.some-transaction.service.gov/uk/completed"
+      assert_requested(:post, %r{/service-feedback}) do |request|
+        JSON.parse(request.body)["service_feedback"]["referrer"] == 'http://referrer.example.com/i-came-from-here'
+      end
+    end
+
+    it "uses the value in the posted params" do
+      posted_params = valid_params
+      posted_params[:service_feedback].delete(:referrer)
+      posted_params[:referrer] = 'http://referrer.example.com/i-came-from-here'
+      submit_service_feedback(params: posted_params)
+
+      assert_requested(:post, %r{/service-feedback}) do |request|
+        JSON.parse(request.body)["service_feedback"]["referrer"] == 'http://referrer.example.com/i-came-from-here'
+      end
+    end
+
+    it "uses the value in the request headers params" do
+      posted_params = valid_params
+      posted_params[:service_feedback].delete(:referrer)
+      posted_params.delete(:referrer)
+      submit_service_feedback(params: posted_params, headers: { 'HTTP_REFERER' => 'http://referrer.example.com/i-came-from-here' })
+
+      assert_requested(:post, %r{/service-feedback}) do |request|
+        JSON.parse(request.body)["service_feedback"]["referrer"] == 'http://referrer.example.com/i-came-from-here'
+      end
+    end
+
+    it "prefers the value in the service_feedback params if all options are present" do
+      posted_params = valid_params
+      posted_params[:service_feedback][:referrer] = 'http://referrer.example.com/i-came-from-here'
+      posted_params[:referrer] = 'http://referrer.example.com/i-did-not-come-from-here'
+      submit_service_feedback(params: posted_params, headers: { 'HTTP_REFERER' => 'http://referrer.example.com/i-did-not-come-from-here-either' })
+
+      assert_requested(:post, %r{/service-feedback}) do |request|
+        JSON.parse(request.body)["service_feedback"]["referrer"] == 'http://referrer.example.com/i-came-from-here'
+      end
     end
   end
 
@@ -66,8 +106,8 @@ RSpec.describe "Service feedback submission", type: :request do
     expect(response.code).to eq("503")
   end
 
-  def submit_service_feedback(headers = {})
-    post "/contact/govuk/service-feedback", valid_params, headers
+  def submit_service_feedback(params: valid_params, headers: {})
+    post "/contact/govuk/service-feedback", params, headers
   end
 
   def valid_params


### PR DESCRIPTION
For: https://trello.com/c/I6aN5mDJ/230-add-full-referrer-value-in-feedex

The forms in frontend that are used to submit service feedback have the
referrer stored in a hidden field added by JS with the name `referrer`.
It is not present in the `service_feedback` params which all our existing
tests assumed.  The outcome of this is that none of the submitted service
feedback has a useful referrer value stored; it's either nil, or since
we merged #206, filled in with the request referer value which will be the
page that the service feedback form was presented on.  That's not a useful
value for the referrer in these cases because we know what page the form
is on, it's the /done page - we want to know where they came from before
they got to the /done page.

We change the contact controller to fetch the referrer from either the
service_feedback hash, or the posted params, or the request.referer (in
that order of preference).