### PR TITLE
Bump gds-api-adapters to 47.2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'notifications-ruby-client'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '47.2'
+  gem 'gds-api-adapters', '~> 47.2'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,7 @@ GEM
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
-    gds-api-adapters (47.2.0)
+    gds-api-adapters (47.2.1)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -166,7 +166,7 @@ GEM
       byebug (~> 9.0)
       pry (~> 0.10)
     rack (1.6.4)
-    rack-cache (1.7.0)
+    rack-cache (1.7.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -308,7 +308,7 @@ DEPENDENCIES
   asset_bom_removal-rails (~> 1.0.0)
   capybara (~> 2.5.0)
   ci_reporter_rspec
-  gds-api-adapters (= 47.2)
+  gds-api-adapters (~> 47.2)
   google-api-client (~> 0.9)
   govuk-content-schema-test-helpers
   govuk-lint


### PR DESCRIPTION
This version of `gds-api-adapters` (see [changelog](https://github.com/alphagov/gds-api-adapters/pull/726/files)) sends the `update_type` of special routes on
put content rather than publish, which is soon to become a requirement of the
Publishing API.

For [this card](https://trello.com/c/UaxgGUDI/1115-require-updatetype-in-put-content)