### PR TITLE
Fix spec mismatch for Redirect content schema 

### DIFF
--- a/lib/redirect_publisher.rb
+++ b/lib/redirect_publisher.rb
@@ -12,7 +12,6 @@ class RedirectPublisher
     logger.info("Registering redirect #{content_id}: '#{current_base_path}' -> '#{destination_path}'")
 
     redirect = {
-      "content_id" => content_id,
       "base_path" => current_base_path,
       "schema_name" => "redirect",
       "document_type" => "redirect",

--- a/spec/lib/redirect_publisher_spec.rb
+++ b/spec/lib/redirect_publisher_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe RedirectPublisher do
     destination_path = "/contact"
 
     expected_redirect = {
-      "content_id" => content_id,
       "base_path" => current_base_path,
       "schema_name" => "redirect",
       "document_type" => "redirect",


### PR DESCRIPTION
Specs for this project were failing due to a schema mismatch for `redirect` content type.

Wasn't caught previously as this project wasn't setup in Jenkins to automatically run specs following schema changes. We have a separate PR open to resolve this. https://github.com/alphagov/govuk-content-schemas/pull/658