### PR TITLE
Update cookie serialiser to json format

### DIFF
--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -2,4 +2,4 @@
 
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
-Rails.application.config.action_dispatch.cookies_serializer = :hybrid
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
Changes the cookie serialiser from the hybrid format to the json format - this is done a continuation of #219 which moved the format to the hybrid format. 

Specs and linting both pass and I have checked this locally