### PR TITLE
Clean up rails config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,12 +1,8 @@
 require File.expand_path('../boot', __FILE__)
 
-# Pick the frameworks you want:
-# require "active_record/railtie"
 require "action_controller/railtie"
 require "action_mailer/railtie"
-#require "active_resource/railtie"
 require "sprockets/railtie"
-# require "rails/test_unit/railtie"
 
 Bundler.require(*Rails.groups)
 
@@ -14,60 +10,19 @@ module Feedback
   class Application < Rails::Application
     config.load_defaults 5.1
 
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration should go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded.
+    config.action_dispatch.rack_cache = nil
 
-    # Custom directories with classes and modules you want to be autoloadable.
-    config.eager_load_paths += %W(#{config.root}/lib)
-
-    # Only load the plugins named here, in the order given (default is alphabetical).
-    # :all can be used as a placeholder for all plugins not explicitly named.
-    # config.plugins = [ :exception_notification, :ssl_requirement, :all ]
-
-    # Activate observers that should always be running.
-    # config.active_record.observers = :cacher, :garbage_collector, :forum_observer
-
-    # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
-    # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
-    # config.time_zone = 'Central Time (US & Canada)'
-
-    # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
-    # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
-    # config.i18n.default_locale = :de
-
-    # Configure the default encoding used in templates for Ruby 1.9.
-    config.encoding = "utf-8"
-
-    # Configure sensitive parameters which will be filtered from the log file.
-    config.filter_parameters += [:password, :name, :email, :email_confirmation, :textdetails, :what_doing, :what_wrong]
-
-    # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    # Use SQL instead of Active Record's schema dumper when creating the database.
-    # This is necessary if your schema can't be completely dumped by the schema dumper,
-    # like if you have constraints or database-specific column types
-    # config.active_record.schema_format = :sql
-
-    # Enforce whitelist mode for mass assignment.
-    # This will create an empty whitelist of attributes available for mass-assignment for all models
-    # in your app. As such, your models will need to explicitly whitelist or blacklist accessible
-    # parameters by using an attr_accessible or attr_protected declaration.
-    # config.active_record.whitelist_attributes = true
-
-    # Enable the asset pipeline
     config.assets.enabled = true
-
-    # Version of your assets, change this if you want to expire all your assets
+    config.assets.precompile += %w(feedback.js feedback.css feedback-ie6.css)
+    config.assets.prefix = '/feedback' # this has to match the path configured in puppet and deploy scripts.
     config.assets.version = '1.0'
 
-    config.assets.prefix = '/feedback' # this has to match the path configured in puppet and deploy scripts.
+    config.eager_load_paths += %W(#{config.root}/lib)
 
-    # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-    config.assets.precompile += %w(feedback.js feedback.css feedback-ie6.css)
+    config.encoding = "utf-8"
 
-    # Disable Rack::Cache
-    config.action_dispatch.rack_cache = nil
+    config.filter_parameters += [:password, :name, :email, :email_confirmation, :textdetails, :what_doing, :what_wrong]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,37 +1,23 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb
-
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
-
-  # Log error messages when you accidentally call methods on nil.
-  config.whiny_nils = true
-
-  # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = false
-
-  # Print deprecation notices to the Rails logger
-  config.active_support.deprecation = :log
-
-  # Only use best-standards-support built into browsers
   config.action_dispatch.best_standards_support = :builtin
 
+  config.action_mailer.raise_delivery_errors = false
 
-  # Do not compress assets
+  config.active_support.deprecation = :log
+
   config.assets.compress = false
-
-  # Expands the lines which load the assets
   config.assets.debug = true
-
   if ENV['GOVUK_ASSET_ROOT'].present?
     config.asset_host = ENV['GOVUK_ASSET_ROOT']
   end
 
+  config.cache_classes = false
+
+  config.consider_all_requests_local = true
+
   config.eager_load = false
+
+  config.whiny_nils = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,69 +1,28 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb
-
-  # Code is not reloaded between requests
-  config.cache_classes = true
-
-  # Full error reports are disabled and caching is turned on
-  config.consider_all_requests_local       = false
+  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
   config.action_controller.perform_caching = true
 
-  # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_files = false
-
-  # Compress JavaScripts and CSS
-  config.assets.compress = true
-
-  # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = false
-
-  # Generate digests for assets URLs
-  config.assets.digest = true
-
-  # Defaults to nil and saved in location specified by config.assets.prefix
-  # config.assets.manifest = YOUR_PATH
-
-  # Specifies the header that your server uses for sending files
-  # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
-  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
-
-  config.log_level = :info
-
-  # Prepend all log lines with the following tags
-  # config.log_tags = [ :subdomain, :uuid ]
-
-  # Use a different logger for distributed setups
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-
-  # Use a different cache store in production
-  # config.cache_store = :mem_cache_store
-
-  # Enable serving of images, stylesheets, and JavaScripts from an asset server
-  config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
-
-  # Precompile additional assets (application.js, application.css, and all non-JS/CSS are already added)
-  # config.assets.precompile += %w( search.js )
-
-  # Disable delivery errors, bad email addresses will be ignored
-  # config.action_mailer.raise_delivery_errors = false
   config.action_mailer.delivery_method = :ses
 
-  # Enable threaded mode
-  # config.threadsafe!
+  config.active_support.deprecation = :notify
 
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found)
+  config.assets.compile = false
+  config.assets.compress = true
+  config.assets.digest = true
+
+  config.cache_classes = true
+
+  config.consider_all_requests_local = false
+
+  config.eager_load = true
+
   config.i18n.fallbacks = true
 
-  # Send deprecation notices to registered listeners
-  config.active_support.deprecation = :notify
+  config.log_level = :info
 
   config.logstasher.enabled = true
   config.logstasher.logger = Logger.new("#{Rails.root}/log/#{Rails.env}.json.log")
   config.logstasher.supress_app_log = true
 
-  config.eager_load = true
+  config.serve_static_files = false
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,37 +1,22 @@
 Rails.application.configure do
-  # Settings specified here will take precedence over those in config/application.rb
-
-  # The test environment is used exclusively to run your application's
-  # test suite. You never need to work with it otherwise. Remember that
-  # your test database is "scratch space" for the test suite and is wiped
-  # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
-
-  # Configure static asset server for tests with Cache-Control for performance
-  config.serve_static_files = true
-  config.static_cache_control = "public, max-age=3600"
-
-  # Log error messages when you accidentally call methods on nil
-  config.whiny_nils = true
-
-  # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
+  config.action_controller.allow_forgery_protection = false
   config.action_controller.perform_caching = false
 
-  # Raise exceptions instead of rendering exception templates
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment
-  config.action_controller.allow_forgery_protection = false
-
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
-
-  # Print deprecation notices to the stderr
   config.active_support.deprecation = :stderr
 
+  config.cache_classes = true
+
+  config.consider_all_requests_local       = true
+
   config.eager_load = false
+
+  config.serve_static_files = true
+
+  config.static_cache_control = "public, max-age=3600"
+
+  config.whiny_nils = true
 end


### PR DESCRIPTION
As part of our work on upgrading rails we're also working to create
a standard for rails configs going forward.

The main things highlighted in this PR are:

- `load_defaults` should be at the top 
- Alphabetise config options
- Group together relevant options (e.g. Assets options are all together)
- Remove any default/unnecessary comments

Once this is merged we'll add this into the [docs](https://docs.publishing.service.gov.uk/manual/upgrade-rails.html)