### PR TITLE
Don't read out remaining characters in screen readers

### DIFF
--- a/app/views/contact/foi/new.html.erb
+++ b/app/views/contact/foi/new.html.erb
@@ -74,7 +74,7 @@
           </p>
         <% end %>
 
-        <p id="textdetailscounter" class="hint" aria-live="polite" aria-atomic="false">(Maximum of 1,200 characters)</p>
+        <p id="textdetailscounter" class="hint">(Maximum of 1,200 characters)</p>
       </div>
     </fieldset>
 

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -54,7 +54,7 @@
           </p>
         <% end %>
 
-        <p id="textdetailscounter" class="hint" aria-live="polite" aria-atomic="false">(Limit is 1200 characters)</p>
+        <p id="textdetailscounter" class="hint">(Limit is 1200 characters)</p>
       </div>
     </fieldset>
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 
 bundle install
-bundle exec rails s -p 3028
+
+if [[ $1 == "--live" ]] ; then
+  GOVUK_APP_DOMAIN=www.gov.uk \
+  GOVUK_WEBSITE_ROOT=https://www.gov.uk \
+  PLEK_SERVICE_CONTENT_STORE_URI=${PLEK_SERVICE_CONTENT_STORE_URI-https://www.gov.uk/api} \
+  PLEK_SERVICE_STATIC_URI=${PLEK_SERVICE_STATIC_URI-assets.publishing.service.gov.uk} \
+  PLEK_SERVICE_RUMMAGER_URI=${PLEK_SERVICE_RUMMAGER_URI-https://www.gov.uk/api} \
+  bundle exec rails s -p 3090
+else
+  bundle exec rails s -p 3028
+fi


### PR DESCRIPTION
The `aria-live="polite"` attribute [instructs screen readers to read out a text every time it changes](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions). Our usage of it here was introduced in https://github.com/alphagov/feedback/commit/bb274875217d0107a023d3743d606ce0cdd742a7 (no PR or commit description).

In the case of this word count widget it results in the remaining count being read out every for every key press, which seems excessive and annoying.

We got [this Zendesk ticket](https://govuk.zendesk.com/agent/tickets/2524610) from a blind user of GOV.UK that brought this to our attention.

While there's a lot to do in accessibility of the feedback mechanisms (https://github.com/alphagov/static/issues/1206), but this seems like a quick win.

https://govuk.zendesk.com/agent/tickets/2524610