### PR TITLE
Add a new email survey for the yes/no feedback banner

### DIFF
--- a/app/models/email_survey.rb
+++ b/app/models/email_survey.rb
@@ -33,6 +33,15 @@ class EmailSurvey
         end_time: Time.zone.parse("2116-12-31").end_of_day,
         name: 'GOV.UK user research'
       ).freeze,
+      # This is the default survey that runs on the footer
+      # hence the long lived start/end times
+      new(
+        id: 'footer_satisfaction_survey',
+        url: 'https://www.smartsurvey.co.uk/s/0087N',
+        start_time: Time.zone.parse("2017-01-01").beginning_of_day,
+        end_time: Time.zone.parse("2116-12-31").end_of_day,
+        name: 'GOV.UK user research'
+      ).freeze,
       new(
         id: 'treetest_pre_test_signup',
         url: 'https://signup.take-part-in-research.service.gov.uk/contact?utm_campaign=crowd-banner&utm_source=Other&utm_medium=gov.uk&t=GDS&id=119',


### PR DESCRIPTION
When you click "No" in the feedback component you're asked to fill in your email address so we can send you a survey. The survey link we currently send (https://www.smartsurvey.co.uk/s/gov-uk) is the default survey that is also present in the blue banner. This makes analysing the data very difficult.

This adds a new EmailSurvey type with a new URL that Katie provided. After this is merged & deployed we can update the feedback component to use `footer_satisfaction_survey` instead of `user_satisfaction_survey` for the `survey_id` (https://github.com/alphagov/govuk_publishing_components/pull/280).
