### PR TITLE
Remove Help with Universal Jobmatch

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,36 @@
 {
   "name": "feedback",
   "scripts": {},
-  "env": {},
+  "env": {
+    "GOVUK_APP_DOMAIN": {
+      "value": "www.gov.uk"
+    },
+    "GOVUK_WEBSITE_ROOT": {
+      "value": "https://www.gov.uk"
+    },
+    "PLEK_SERVICE_CONTENT_STORE_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_RUMMAGER_URI": {
+      "value": "https://www.gov.uk/api"
+    },
+    "PLEK_SERVICE_STATIC_URI": {
+      "value": "assets.digital.cabinet-office.gov.uk"
+    },
+    "RAILS_SERVE_STATIC_ASSETS": {
+      "value": "yes"
+    },
+    "RAILS_SERVE_STATIC_FILES": {
+      "value": "yes"
+    },
+    "SECRET_KEY_BASE": {
+      "generator": "secret"
+    },
+    "HEROKU_APP_NAME": {
+      "required": true
+    }
+  },
+  "image": "heroku/ruby",
   "formation": {},
   "addons": [],
   "buildpacks": []

--- a/config/contact-links.csv
+++ b/config/contact-links.csv
@@ -1,7 +1,6 @@
 Type,URL,Title,Description
 popular,/contact-the-dvla,Driving licences and car tax,"Contact DVLA for questions about driving, vehicle tax and registrations."
 popular,/government/organisations/hm-revenue-customs/contact,HM Revenue and Customs (HMRC),"Contact HMRC for questions about tax, including self assessment and PAYE."
-popular,/contact/look-for-jobs,Help with Universal Jobmatch,"Retrieve your lost login details or get help using Universal Jobmatch."
 popular,/passport-advice-line,Passport advice and complaints,"Get help with your passport application and renewals if you're a British Citizen."
 popular,/contact-student-finance-england,Student Finance England,"Get help with student loan applications and grants."
 popular,/contact-jobcentre-plus,Jobcentre Plus,"Get advice on benefits such as Jobseeker's Allowance (JSA)."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,6 @@ Rails.application.routes.draw do
       post 'email-survey-signup.js', to: 'email_survey_signup#create', defaults: { format: :js }
       resources 'page_improvements', only: [:create], format: false
     end
-
-    get 'look-for-jobs', to: redirect("https://jobsearch.direct.gov.uk/ContactUs.aspx")
   end
 
   root to: redirect("/contact")


### PR DESCRIPTION
We no longer need to present this link on the page and as such we no
longer need the route.
[Trello](https://trello.com/c/EUF7jT0F/526-delete-2-lines-of-content-from-govuk-contact)