### PR TITLE
Mask email addresses in the URL submitted with feedback responses

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -61,6 +61,10 @@
   GOVUK.feedback.prepopulateFormBasedOnReferrer = function () {
     var specificPage = GOVUK.cookie('govuk_contact_referrer') || document.referrer;
 
+    // Mask email addresses
+    var emailPattern = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+    specificPage = specificPage.replace(emailPattern, '[email]');
+
     // Preopulate specific page field
     $('#link').val(specificPage);
 

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -104,6 +104,7 @@ private
 
   def referrer_attribute
     referrer = contact_params[:referrer] || params[:referrer] || request.referrer
+    referrer = referrer.gsub(/[^\s=\/?&]+(?:@|%40)[^\s=\/?&]+/, '[email]') if referrer.present?
     referrer.present? ? { referrer: referrer } : {}
   end
 


### PR DESCRIPTION
The query string may contain email addresses or other personal data which the user may not wish to be processed in this way

https://trello.com/c/jKitCyZI/311-remove-emails-from-ga-events-on-email-alert-frontend-pages