### PR TITLE
Replace poltergeist with govuk test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,12 +37,12 @@ gem 'govuk_app_config', '~> 1.8.0'
 
 group :development, :test do
   gem 'govuk-content-schema-test-helpers'
+  gem 'govuk_test'
   gem 'govuk-lint'
   gem 'rspec-rails', '~> 3.8'
   gem 'rails-controller-testing'
   gem 'capybara', '~> 3.7'
   gem 'webmock', '~> 3.4.2', require: false
-  gem 'poltergeist'
   gem 'shoulda-matchers', '~> 3.0.1'
   gem 'test-unit', '3.2.8'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     asset_bom_removal-rails (1.0.2)
       rails (>= 4.2)
@@ -58,12 +60,16 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.1)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     ci_reporter (2.0.0)
       builder (>= 2.1.2)
     ci_reporter_rspec (1.0.0)
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
-    cliver (0.3.2)
     coderay (1.1.2)
     commander (4.4.6)
       highline (~> 1.7.2)
@@ -138,6 +144,11 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
+    govuk_test (0.1.0)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     hashdiff (0.3.7)
     highline (1.7.10)
     htmlentities (4.3.4)
@@ -147,6 +158,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     invalid_utf8_rejector (0.0.4)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     json (2.1.0)
     json-schema (2.8.0)
@@ -194,10 +206,6 @@ GEM
     parser (2.5.1.2)
       ast (~> 2.4.0)
     plek (2.1.1)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     power_assert (1.1.1)
     powerpack (0.1.2)
     pry (0.11.3)
@@ -207,6 +215,7 @@ GEM
       byebug (~> 9.1)
       pry (~> 0.10)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.5)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -291,6 +300,7 @@ GEM
     rubocop-rspec (1.29.1)
       rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sanitize (4.6.6)
       crass (~> 1.0.2)
@@ -310,6 +320,9 @@ GEM
     scss_lint (0.57.0)
       rake (>= 0.9, < 13)
       sass (~> 3.5.5)
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.0.1)
@@ -379,10 +392,10 @@ DEPENDENCIES
   govuk_app_config (~> 1.8.0)
   govuk_frontend_toolkit (= 7.6.0)
   govuk_publishing_components (~> 9.16.1)
+  govuk_test
   invalid_utf8_rejector
   notifications-ruby-client
   plek (~> 2.1.1)
-  poltergeist
   pry-byebug
   rack_strip_client_ip (= 0.0.2)
   rails (= 5.2.1)
@@ -398,4 +411,4 @@ DEPENDENCIES
   webmock (~> 3.4.2)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -276,8 +276,9 @@ RSpec.describe "Contact", type: :request do
 
     click_on "Return to the GOV.UK home page"
 
-    cookies = page.driver.cookies
-    expect(cookies.keys).to include('govuk_contact_referrer')
-    expect(cookies['govuk_contact_referrer'].value).to match(/\/thankyou$/)
+    cookies = page.driver.browser.manage.all_cookies
+    contact_referrer_cookie = cookies.find { |c| c[:name] == 'govuk_contact_referrer' }
+    expect(contact_referrer_cookie).not_to be_nil
+    expect(contact_referrer_cookie[:value]).to match(/\/thankyou$/)
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,11 +1,1 @@
-require 'capybara/poltergeist'
-
-Capybara.server = :webrick
-Capybara.javascript_driver = :poltergeist
-Capybara.ignore_hidden_elements = false
-
-Capybara.register_driver :poltergeist do |app|
-  Capybara::Poltergeist::Driver.new(app, phantomjs_options: ['--ssl-protocol=TLSv1'])
-end
-
 RSpec.configuration.include Capybara::DSL, type: :request

--- a/spec/support/govuk_contact.rb
+++ b/spec/support/govuk_contact.rb
@@ -2,13 +2,13 @@ RSpec.shared_examples_for "a GOV.UK contact" do
   context "on GET" do
     it "returns http success" do
       get :new
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it "should set cache control headers for 10 mins" do
       get :new
       expect(response.headers["Cache-Control"]).to eq("max-age=600, public")
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it "should return 406 when text/html isn't acceptable" do

--- a/spec/support/govuk_test.rb
+++ b/spec/support/govuk_test.rb
@@ -1,0 +1,1 @@
+GovukTest.configure


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

Poltergeist isn't maintained, replace with Selenium headless chrome driver via alphagov/govuk_test