### PR TITLE
Add hidden field in contact form

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -26,6 +26,13 @@ class ContactController < ApplicationController
 
   def create
     data = contact_params.merge(browser_attributes)
+
+    unless data[:govuk_thanks_martha].blank?
+      hide_report_a_problem_form_in_response
+      redirect_to contact_anonymous_feedback_thankyou_path
+      return
+    end
+
     ticket = ticket_class.new data
 
     if ticket.valid?

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -93,6 +93,7 @@
         <label for="email">Your email address</label>
         <input name="contact[email]" id="email" type="email" class="email" value="<%= (@old ? @old[:email] : '') %>">
         <span class="hint">We'll only use this to reply to your message.</span>
+        <input aria-hidden="true" type="hidden" name="contact[govuk_thanks_martha]">
 
       </p>
     </fieldset>

--- a/spec/controllers/contact/govuk_controller_spec.rb
+++ b/spec/controllers/contact/govuk_controller_spec.rb
@@ -13,9 +13,24 @@ RSpec.describe Contact::GovukController, type: :controller do
         email: "test@test.com",
         location: "all",
         textdetails: "Testing, testing, 1, 2, 3...",
+        govuk_thanks_martha: "",
       }
     }
   end
+
+  let(:params_with_hidden_field_filled) do
+    {
+      contact: {
+        name: "Joe Bloggs",
+        email: "test@test.com",
+        location: "all",
+        textdetails: "Testing, testing, 1, 2, 3...",
+        govuk_thanks_martha: "We are the robots",
+      }
+    }
+  end
+
+
 
   it_behaves_like "a GOV.UK contact"
 
@@ -27,6 +42,16 @@ RSpec.describe Contact::GovukController, type: :controller do
 
       expect(response).to be_redirect
       expect(stub_post).to have_been_made
+    end
+  end
+
+  context "with a filled in hidden form" do
+    it "should redirect to the anonymous feedback thank you" do
+      stub_post = stub_support_named_contact_creation
+
+      post :create, params: params_with_hidden_field_filled
+
+      expect(stub_post).to_not have_been_made
     end
   end
 end


### PR DESCRIPTION
paired with @thomasleese 

To stop automatic submission of our forms, we are adding a hidden field
in to the contact form. We have set aria-hidden to true to help with
accessibility.