### PR TITLE
Stop bad robots with qq email addresses

### DIFF
--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -26,10 +26,12 @@ class ContactTicket < Ticket
 
   def save
     if valid?
-      if anonymous?
-        Rails.application.config.support_api.create_anonymous_long_form_contact(ticket_details)
-      else
-        Rails.application.config.support.create_named_contact(ticket_details)
+      unless email_qq
+        if anonymous?
+          Rails.application.config.support_api.create_anonymous_long_form_contact(ticket_details)
+        else
+          Rails.application.config.support.create_named_contact(ticket_details)
+        end
       end
     end
   end
@@ -66,6 +68,10 @@ private
     if email.blank? && name.present?
       @errors.add :email, 'The email field cannot be empty'
     end
+  end
+
+  def email_qq
+    /[0-9]+@qq.com$/.match?(email)
   end
 
   def validate_link

--- a/spec/models/contact_ticket_spec.rb
+++ b/spec/models/contact_ticket_spec.rb
@@ -24,6 +24,15 @@ RSpec.describe ContactTicket, type: :model do
     ContactTicket.new valid_named_ticket_details.merge(options)
   end
 
+  def named_bad_ticket
+    ContactTicket.new valid_named_ticket_details.merge(name: "Bad Robot", email: "123456@qq.com")
+  end
+
+  it "should not create named contact with a bad ticket" do
+    expect(Rails.application.config.support).to_not receive(:create_named_contact)
+    named_bad_ticket.save
+  end
+
   it "should validate anonymous tickets" do
     expect(anon_ticket).to be_valid
   end


### PR DESCRIPTION
paired with @thomasleese 

We are receiving large amounts of spam. This should hopefully alleviate
it by not sending support tickets when the email matches a particular
regex.