### PR TITLE
Ban some email addresses being used for spam

### DIFF
--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -26,7 +26,7 @@ class ContactTicket < Ticket
 
   def save
     if valid?
-      unless email_qq
+      unless bad_email_address?
         if anonymous?
           Rails.application.config.support_api.create_anonymous_long_form_contact(ticket_details)
         else
@@ -70,8 +70,23 @@ private
     end
   end
 
-  def email_qq
-    /[0-9]+@qq.com$/.match?(email)
+  def bad_email_address?
+    bad_domains = Regexp.union(
+      /\A*@.*\.beameagle.top$/,
+      /\A*@.*\.bishop-knot.xyz$/,
+      /\A*@.*\.captainmaid.top$/,
+      /\A*@.*\.eaglefight.top$/,
+      /\A*@.*\.gull-minnow.top$/,
+      /\A*@.*\.hensailor.xyz$/,
+      /\A*@.*\.lady-and-lunch.xyz$/,
+      /\A*@.*\.marver-coats.xyz$/,
+      /\A*@.*\.pine-and-onyx.xyz$/,
+      /\A*@.*\.stars-and-glory.top$/,
+      /\A*@.*\.veinflower.xyz$/,
+      /\A*@qq.com$/
+    )
+
+    bad_domains.match?(email)
   end
 
   def validate_link

--- a/spec/models/contact_ticket_spec.rb
+++ b/spec/models/contact_ticket_spec.rb
@@ -24,13 +24,18 @@ RSpec.describe ContactTicket, type: :model do
     ContactTicket.new valid_named_ticket_details.merge(options)
   end
 
-  def named_bad_ticket
-    ContactTicket.new valid_named_ticket_details.merge(name: "Bad Robot", email: "123456@qq.com")
-  end
-
-  it "should not create named contact with a bad ticket" do
-    expect(Rails.application.config.support).to_not receive(:create_named_contact)
-    named_bad_ticket.save
+  context "with a bad email address" do
+    it "should not create a named contact" do
+      bad_actors = [
+        "12345@qq.com",
+        "james@one.beameagle.top"
+      ]
+      bad_actors.each do |bad_actor|
+        bad_ticket = ContactTicket.new valid_named_ticket_details.merge(name: "Bad Robot", email: bad_actor)
+        expect(Rails.application.config.support).to_not receive(:create_named_contact)
+        bad_ticket.save
+      end
+    end
   end
 
   it "should validate anonymous tickets" do


### PR DESCRIPTION
These are regular bad actors in the system. Stop them outright. There is almost certainly a more elegant solution by putting these in secrets. This will, however, work for now.