### PR TITLE
Add bearer tokens for support-api authentication

### DIFF
--- a/config/initializers/support_app.rb
+++ b/config/initializers/support_app.rb
@@ -1,6 +1,7 @@
 require 'gds_api/support'
 require 'gds_api/support_api'
 
-token = ENV.fetch('SUPPORT_API_BEARER_TOKEN', 'xxxxx')
-Rails.application.config.support = GdsApi::Support.new(Plek.current.find('support'), bearer_token: token)
-Rails.application.config.support_api = GdsApi::SupportApi.new(Plek.current.find('support-api'))
+support_token = ENV.fetch('SUPPORT_BEARER_TOKEN', 'xxxxx')
+support_api_token = ENV.fetch('SUPPORT_API_BEARER_TOKEN', 'xxxxx')
+Rails.application.config.support = GdsApi::Support.new(Plek.current.find('support'), bearer_token: support_token)
+Rails.application.config.support_api = GdsApi::SupportApi.new(Plek.current.find('support-api'), bearer_token: support_api_token)


### PR DESCRIPTION
Trello: https://trello.com/c/WR2MNxo6

Related to:

* https://github.com/alphagov/govuk-puppet/pull/8479
* https://github.com/alphagov/support-api/pull/266

Passes the bearer token needed to authenticate with support-api using signon