### PR TITLE
Enable logging for the GdsApi Adapters

### DIFF
--- a/config/initializers/gds_api.rb
+++ b/config/initializers/gds_api.rb
@@ -1,0 +1,5 @@
+require 'gds_api/base'
+
+GdsApi::Base.default_options = {
+  logger: Rails.logger
+}


### PR DESCRIPTION
Log information about requests made by feedback. This may be useful
when Support and Support API are migrated to AWS.