### PR TITLE
Notify Sentry about invalid survey submission

### DIFF
--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -19,6 +19,17 @@ module Contact
           @errors = ticket.errors.to_hash
           @old = data
 
+          # To be removed after 21/2/2019
+          GovukError.notify(
+            "Invalid email survey submitted",
+            extra: {
+              params: contact_params,
+              errors: ticket.errors,
+              request: request,
+            },
+            level: "debug",
+          )
+
           respond_to_invalid_submission(ticket)
         end
       end


### PR DESCRIPTION
When a user answers "No" to the "Is this page useful?" at the bottom of the page, they can fill in an email address. We're seeing that the endpoint that receives the email address (`/contact/govuk/email-survey-signup`) is returning 422 quite a lot - about 800 in the last week.

https://kibana.logit.io/s/0ea55710-075b-4eab-bfc3-475f28cdd0c3/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-7d,mode:quick,to:now))&_a=(columns:!(request,status),index:'*-*',interval:auto,query:(query_string:(analyze_wildcard:!t,query:'path:%22%2Fcontact%2Fgovuk%2Femail-survey-signup%22+AND+status:422')),sort:!('@timestamp',desc))

This commit adds a notification to Sentry so we can figure out why these requests are being rejected. Currently this info isn't logged, so we haven't got a good idea.

The statement should be removed in a month, because we should have figured it out by then.