### PR TITLE
Send readable data to Sentry

### DIFF
--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -23,9 +23,8 @@ module Contact
           GovukError.notify(
             "Invalid email survey submitted",
             extra: {
-              params: contact_params,
-              errors: ticket.errors,
-              request: request,
+              ticket: ticket,
+              errors: ticket.errors.full_messages,
             },
             level: "debug",
           )


### PR DESCRIPTION
The payload that we're sending currently is wrong, so Sentry just displays `"#<ActiveModel::Errors:0x00007ff3765e6a48>"` for errors and for params "[Filtered]".

https://sentry.io/govuk/app-feedback/issues/855155869/?query=is%3Aunresolved