### PR TITLE
Add route for business finder feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'notifications-ruby-client'
 if ENV['API_DEV']
   gem 'gds-api-adapters', path: '../gds-api-adapters'
 else
-  gem 'gds-api-adapters', '57.2.3'
+  gem 'gds-api-adapters', '57.3.1'
 end
 
 gem 'govuk_app_config', '~> 1.11.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
-    gds-api-adapters (57.2.3)
+    gds-api-adapters (57.3.1)
       addressable
       link_header
       null_logger
@@ -391,7 +391,7 @@ PLATFORMS
 DEPENDENCIES
   asset_bom_removal-rails (~> 1.0.2)
   ci_reporter_rspec
-  gds-api-adapters (= 57.2.3)
+  gds-api-adapters (= 57.3.1)
   google-api-client (~> 0.26)
   govuk-content-schema-test-helpers
   govuk-lint

--- a/app/controllers/contact/govuk/content_improvement_controller.rb
+++ b/app/controllers/contact/govuk/content_improvement_controller.rb
@@ -1,0 +1,15 @@
+class Contact::Govuk::ContentImprovementController < ContactController
+  def create
+    begin
+      response = Rails.application.config.support_api.create_content_improvement_feedback(feedback_params)
+
+      render json: { status: 'success' }, status: response.code
+    rescue GdsApi::HTTPUnprocessableEntity => e
+      render json: e.error_details, status: e.code
+    end
+  end
+
+  def feedback_params
+    params.slice(:description)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       post 'assisted-digital-survey-feedback', to: "assisted_digital_feedback#create", format: false
       post 'email-survey-signup', to: 'email_survey_signup#create', format: false
       post 'email-survey-signup.js', to: 'email_survey_signup#create', defaults: { format: :js }
+      post 'content_improvement', to: 'content_improvement#create', defaults: { format: :js }
       resources 'page_improvements', only: [:create], format: false
     end
   end

--- a/spec/requests/content_improvement_spec.rb
+++ b/spec/requests/content_improvement_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/support_api'
+
+RSpec.describe "Content Improvement Feedback", type: :request do
+  include GdsApi::TestHelpers::SupportApi
+
+  let(:common_headers) { { "Accept" => "application/json", "Content-Type" => "application/json" } }
+  let(:support_api_url) { Plek.current.find('support-api') }
+
+  it 'submits the feedback to the support api' do
+    stub_any_support_api_call
+
+    post '/contact/govuk/content_improvement',
+      params: {
+      description: "I need this page to exist"
+      }.to_json,
+      headers: common_headers
+
+    expected_request = a_request(:post, support_api_url + "/anonymous-feedback/content_improvement")
+      .with(body: {
+              "description" => "I need this page to exist",
+            })
+
+    expect(expected_request).to have_been_made
+  end
+
+  it "responds successfully" do
+    params = { description: "I need this page to exist" }
+    stub_support_api_create_content_improvement_feedback(params)
+
+    post '/contact/govuk/content_improvement', params: params.to_json, headers: common_headers
+
+    expect(response.code).to eq('201')
+    expect(response_hash).to include('status' => 'success')
+  end
+
+  context "when the Support API isn't available" do
+    it "responds with an error" do
+      support_api_isnt_available
+
+      post "/contact/govuk/content_improvement",
+        params: { description: "Huh?" }.to_json,
+        headers: common_headers
+
+      assert_response :error
+      expect(response_hash).to include('status' => 'error')
+    end
+  end
+
+  it "returns an error if the required attributes aren't supplied" do
+    url = support_api_url + "/anonymous-feedback/content_improvement"
+    stub_http_request(:post, url)
+      .with(body: {}.to_json)
+      .to_return(
+        status: 422,
+        body: { status: 'error', errors: [{ description: "can't be blank" }] }.to_json,
+        headers: { "Content-Type" => "application/json; charset=utf-8" }
+    )
+
+    post "/contact/govuk/content_improvement",
+      params: {}.to_json,
+      headers: common_headers
+
+    expect(response.code).to eq('422')
+    expect(response_hash).to include('status' => 'error')
+    expect(response_hash).to include('errors' => [{ 'description' => "can't be blank" }])
+  end
+
+  it "only sends permitted attributes to the Support API" do
+    stub_any_support_api_call
+
+    post "/contact/govuk/content_improvement",
+      params: {
+        description: "The title is the wrong colour.",
+        another: "attribute"
+      }.to_json,
+      headers: common_headers
+
+    expected_request = a_request(:post, Plek.current.find('support-api') + "/anonymous-feedback/content_improvement")
+      .with(body: { "description" => "The title is the wrong colour." })
+
+    expect(expected_request).to have_been_made
+  end
+
+  def stub_support_api_create_content_improvement_feedback(params)
+    post_stub = stub_http_request(:post, "#{support_api_url}/anonymous-feedback/content_improvement")
+    post_stub.with(body: params)
+    post_stub.to_return(status: 201)
+  end
+
+  def response_hash
+    JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
# What
Adds a new endpoint at `/contact/govuk/content_improvement` to allow posting feedback about the EU Exit business readiness finder.

# Why

We need to know what is missing from the EU Exit Business Readiness Finder.

Trello: https://trello.com/c/a9WXTd6f/64-build-a-feedback-component-to-sit-below-business-finder-results