### PR TITLE
Don't send form submissions to Sentry

### DIFF
--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -19,16 +19,6 @@ module Contact
           @errors = ticket.errors.to_hash
           @old = data
 
-          # To be removed after 21/2/2019
-          GovukError.notify(
-            "Invalid email survey submitted",
-            extra: {
-              ticket: ticket,
-              errors: ticket.errors.full_messages,
-            },
-            level: "debug",
-          )
-
           respond_to_invalid_submission(ticket)
         end
       end


### PR DESCRIPTION
This was added in https://github.com/alphagov/feedback/pull/619, but Sentry doesn't record any of the parameters. We've recently fixed an issue in the feedback component (https://github.com/alphagov/govuk_publishing_components/pull/719), so this logging might not even be necessary anymore.