### PR TITLE
Remove test-unit dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,5 @@ group :development, :test do
   gem 'rails-controller-testing'
   gem 'rspec-rails', '~> 3.8'
   gem 'shoulda-matchers', '~> 3.0.1'
-  gem 'test-unit', '3.2.9'
   gem 'webmock', '~> 3.5.1', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,7 +208,6 @@ GEM
     parser (2.6.0.0)
       ast (~> 2.4.0)
     plek (2.1.1)
-    power_assert (1.1.3)
     powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -353,8 +352,6 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     statsd-ruby (1.4.0)
-    test-unit (3.2.9)
-      power_assert
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
@@ -409,10 +406,9 @@ DEPENDENCIES
   sass-rails (~> 5.0.7)
   shoulda-matchers (~> 3.0.1)
   slimmer (~> 13.1.0)
-  test-unit (= 3.2.9)
   uglifier (~> 4.1.20)
   valid_email (~> 0.1.2)
   webmock (~> 3.5.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
I don't think any of the tests use this any more.

From this build output:
> [build] 268 examples, 0 failures

From the [latest master build output](https://ci.integration.publishing.service.gov.uk/job/feedback/job/master/631/console):
> [build] 268 examples, 0 failures