### PR TITLE
Use `exclude?` instead of negated `include?` for low quality feedback

### DIFF
--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -7,5 +7,5 @@ Rails.application.config.problem_report_spam_matchers = [
 
   # get rid of very low-quality feedback where "what_wrong" and "what_doing" are
   # either single words or missing completely
-  lambda { |ticket| !ticket.what_wrong.include?(" ") && !ticket.what_doing.include?(" ") },
+  lambda { |ticket| ticket.what_wrong.exclude?(" ") && ticket.what_doing.exclude?(" ") },
 ].freeze


### PR DESCRIPTION
- Using `exclude?` makes it easier to see the negation up front.
  When reading this, I didn't notice the `!` at the front and puzzled over
  why we would be rejecting spaces.