### PR TITLE
Rename the honeypot form field

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -2,7 +2,7 @@ require 'uri'
 
 class Ticket
   include ActiveModel::Validations
-  attr_accessor :val, :user_agent
+  attr_accessor :giraffe, :user_agent
   attr_writer :url
 
   # This is deliberately higher than the max character count
@@ -11,7 +11,7 @@ class Ticket
   # 1 character long.
   FIELD_MAXIMUM_CHARACTER_COUNT = 1250
 
-  validate :validate_val
+  validate :validate_giraffe
   validates_length_of :url, maximum: 2048
   validates_length_of :user_agent, maximum: 2048
 
@@ -23,7 +23,7 @@ class Ticket
   end
 
   def spam?
-    errors[:val] && errors[:val].any?
+    errors[:giraffe] && errors[:giraffe].any?
   end
 
   def url
@@ -44,8 +44,8 @@ class Ticket
 
 private
 
-  def validate_val
-    # val is used as a naive bot-preventor
-    @errors.add :val unless val.blank?
+  def validate_giraffe
+    # giraffe is used as a naive bot-preventor
+    @errors.add :giraffe unless giraffe.blank?
   end
 end

--- a/app/views/shared/_spam_honeypot.html.erb
+++ b/app/views/shared/_spam_honeypot.html.erb
@@ -1,5 +1,5 @@
 <%# Honeypot field intended to reduce spam %>
 <div class="visually-hidden" aria-hidden="true">
-  <label for="val">Ignore if you're not a robot</label>
-  <input type="text" tabindex="-1" autocomplete="off" id="val" name="<%= "#{form_name}" %>[val]"/>
+  <label for="giraffe">Ignore if you're not a robot</label>
+  <input type="text" tabindex="-1" autocomplete="off" id="giraffe" name="<%= "#{form_name}" %>[giraffe]"/>
 </div>

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Ticket, type: :model do
   it { is_expected.to allow_value("https://www.gov.uk/done/whatever").for(:url) }
   it { is_expected.not_to be_spam }
 
-  context "a bot has populated the val field" do
-    let(:subject) { Ticket.new(val: "xxxxx") }
+  context "a bot has populated the giraffe field" do
+    let(:subject) { Ticket.new(giraffe: "xxxxx") }
     it { is_expected.to be_spam }
     it { is_expected.not_to be_valid }
   end

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -52,12 +52,12 @@ RSpec.describe "Contact", type: :request do
     assert_requested(stub_post)
   end
 
-  it "should not accept spam (ie a request with val field filled in)" do
+  it "should not accept spam (ie a request with honeypot field filled in)" do
     visit "/contact/govuk"
 
     choose "location-all"
     fill_in_valid_contact_details_and_description
-    fill_in "val", with: "test val"
+    fill_in "giraffe", with: "test val"
     click_on "Send message"
 
     no_post_calls_should_have_been_made

--- a/spec/requests/foi_spec.rb
+++ b/spec/requests/foi_spec.rb
@@ -41,14 +41,14 @@ RSpec.describe "FOI", type: :request do
     expect(response.body).to include("Please check the form")
   end
 
-  it "should not accept spam (ie requests with val field filled in)" do
+  it "should not accept spam (ie requests with honeypot field filled in)" do
     visit "/contact/foi"
 
     fill_in "Your name", with: "test name"
     fill_in "Your email address", with: "a@a.com"
     fill_in "Confirm your email address", with: "a@a.com"
     fill_in "Include a detailed description of the information you're looking for. Don't include any personal or financial information.", with: "test foi request"
-    fill_in "val", with: "test val"
+    fill_in "giraffe", with: "test val"
     click_on "Submit your Freedom of Information request"
 
     expect(page.status_code).to eq(400)


### PR DESCRIPTION
- We hypothesise that some bots have "remembered" that `val` is our
  honeypot field and have therefore stopped filling it in.
- This is an extremely basic step 1 in attempting to reduce spam for the
  user support team, while not inconveniencing real users.
- We considered doing an A/B test, but it's one form field and the
  effort outweighed the value. We have existing Graphite metrics for
  valid vs. invalid responses, so will be able to tell if the number of
  invalid goes up - ie if we've made it worse (regressed) or better.

For reviewers:
- We chose `giraffe` as a random name that wasn't `val` and wasn't the name of a real field. We're open to other more sensible suggestions. 😳

https://trello.com/c/N4F1caLY/335-test-an-improvement-to-the-honeypot-in-govuk-feedback-app-to-see-if-it-reduces-spam

("We" == @alphagov/re-autom8.)