### PR TITLE
Fix broken link on Contact page

### DIFF
--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -7,7 +7,7 @@
     <p>This form is for issues to do with the GOV.UK website.</p>
     <p>You can use it to ask a question, report a problem or suggest an improvement to the GOV.UK team.</p>
     <p>We can’t reply to you with advice. We don’t have access to information about you held by government departments.</p>
-    <p>If you have a question about a government service or policy, check the <a href="/help">help pages</a> or contact the <a hef="/government/organisations">government department</a> directly.</p>
+    <p>If you have a question about a government service or policy, check the <a href="/help">help pages</a> or contact the <a href="/government/organisations">government department</a> directly.</p>
 
     <%= render partial: "shared/spam_honeypot", locals: { form_name: 'contact' } %>
 


### PR DESCRIPTION
The "government organisations" link has a typo on the href - hence why it is hoverable but not clickable.