### PR TITLE
Improve tests on spam detection for RaP submissions

### DIFF
--- a/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
+++ b/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
@@ -3,10 +3,6 @@ require 'rails_helper'
 RSpec.describe Contact::Govuk::ProblemReportsController, type: :controller do
   render_views
 
-  before :each do
-    allow_any_instance_of(ReportAProblemTicket).to receive(:save).and_return(true)
-  end
-
   describe "POST" do
     context "with a valid report_a_problem submission" do
       context "html request" do

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -42,12 +42,20 @@ RSpec.describe ReportAProblemTicket, type: :model do
     expect(ticket(source: 'xxx').source).to be_nil
   end
 
-  it "should know if it's spam or not" do
-    allow(Rails.application.config)
-      .to receive(:problem_report_spam_matchers)
-      .and_return([lambda { |message| message.what_wrong.include?("spammy spam") }])
+  context "spam detection" do
+    it "should mark single word submissions as spam" do
+      expect(ticket(what_doing: 'oneword', what_wrong: '')).to be_spam
+      expect(ticket(what_doing: '', what_wrong: 'oneword')).to be_spam
+      expect(ticket(what_doing: 'oneword', what_wrong: 'oneword')).to be_spam
+    end
 
-    expect(ticket(what_wrong: "spammy spam")).to be_spam
-    expect(ticket(what_wrong: "normal content")).to_not be_spam
+    it 'should mark Web Cruiser scanning as spam' do
+      expect(ticket(what_doing: 'WCRTESTINP scanning')).to be_spam
+      expect(ticket(what_wrong: 'WCRTESTINP scanning')).to be_spam
+    end
+
+    it 'should allow genuine submissions' do
+      expect(ticket(what_doing: 'browsing', what_wrong: 'it broke')).to_not be_spam
+    end
   end
 end


### PR DESCRIPTION
As part of investigating an issue of Report a Problem (RaP) tickets
dropping recently (https://govuk.zendesk.com/agent/tickets/3649249)
we have improved the tests to ensure the spam detection we have in
place is clearer and working as expected.

Paired with @edwardkerry

Trello card: https://trello.com/c/uoTvgoJn/948-report-a-problem-tickets-not-coming-through-to-1st-line-support