### PR TITLE
Remove “robot” from the honeypot contact form code

### DIFF
--- a/app/views/shared/_spam_honeypot.html.erb
+++ b/app/views/shared/_spam_honeypot.html.erb
@@ -1,5 +1,5 @@
 <%# Honeypot field intended to reduce spam %>
 <div class="visually-hidden" aria-hidden="true">
-  <label for="giraffe">Ignore if you're not a robot</label>
+  <label for="giraffe"></label>
   <input type="text" tabindex="-1" autocomplete="off" id="giraffe" name="<%= "#{form_name}" %>[giraffe]"/>
 </div>


### PR DESCRIPTION
We tried changing the honeypot field name from “val” to “giraffe” in a previous iteration of testing spam improvements. That didn’t have any impact.
I was suggested that robots might be ignoring it as the label in the HTML for that field is “ignore if you’re not a robot”, and the robots were catching “robot”.

Single: @matthewculluum-gds