### PR TITLE
Read remaining characters when threshold reached

### DIFF
--- a/app/assets/javascripts/feedback.js
+++ b/app/assets/javascripts/feedback.js
@@ -34,7 +34,25 @@
 
   GOVUK.feedback.handleCounter = function (counted) {
     var counterId = '#' + counted.id + 'counter';
-    $(counterId).html((1200 - counted.value.length) +  " characters remaining (limit is 1200 characters)");
+    var maxLength = 1200
+    var currentLength = counted.value.length
+    var remainingNumber = maxLength - currentLength
+    var thresholdValue = maxLength * 90 / 100 // 90% of the total maximum length
+    var charVerb = (remainingNumber < 0) ? 'too many' : 'remaining'
+    var charNoun = 'character' + ((remainingNumber === -1 || remainingNumber === 1) ? '' : 's')
+    var displayNumber = Math.abs(remainingNumber)
+    $(counterId).html((displayNumber) + ' ' + charNoun + ' ' + charVerb + " (limit is " + maxLength + " characters)");
+    
+    // remove aria attributes when users start typing
+    $(counterId).removeAttr('aria-live aria-atomic')
+
+    // only add the screenreader anouncements when threshold is reached
+    if (currentLength > thresholdValue) {
+      $(counterId).attr({
+        "aria-live": "polite",
+        "aria-atomic": "false"
+      })
+    }
   }
 
   GOVUK.feedback.initCounters = function () {


### PR DESCRIPTION
## Problem:

> __From the user:__
> 
> I am blind and am using the NVDA screen reader.
> 
> I have noticed something that is rather commenn in todays websites.
> 
> When I type in the edit box to send an email to everyone at the gov.org site, the screen reader will read out something like this: 1199 characters remaining (limit is 1200 characters) this is every time i press a letter on the keyboard so 1199 becomes 1198 and so on.
> 
> Ideally we'd only want to enable screenreader character count announcements only when a certain threshold is reached.

## Solution

This PR amend the character counter javascript so that it removes aria- attributes when users start typing (leaving the initial limit announcement intact) and attaches attributes only when 90% character count threshold is reached.

Ideal solution would be to remove this custom script and use the https://govuk-publishing-components.herokuapp.com/component-guide/character_count but that would bring BE work as well