### PR TITLE
Use modern layout

### DIFF
--- a/app/assets/stylesheets/design-patterns/_forms.scss
+++ b/app/assets/stylesheets/design-patterns/_forms.scss
@@ -112,6 +112,8 @@
   fieldset {
     margin: 0;
     margin-top: 2em;
+    margin-bottom: 2em;
+
     // Make legends in nested fieldsets look like labels
     fieldset {
       margin-top: 0;

--- a/app/assets/stylesheets/views/feedback.scss
+++ b/app/assets/stylesheets/views/feedback.scss
@@ -1,25 +1,5 @@
 .category-page {
 
-  header.page-header {
-
-    div {
-      h1 {
-        @include bold-48;
-        width: 75%;
-
-        @include media(mobile) {
-          width: auto;
-        }
-      }
-
-      h2 {
-        @include core-24;
-        color: inherit;
-        margin: 0;
-      }
-    }
-  }
-
   .inner {
     padding: 0;
     margin: 0;

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   rescue_from GdsApi::BaseError, with: :unable_to_create_ticket_error
 
   include Slimmer::Template
-  slimmer_template 'wrapper'
 
 protected
 

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -101,9 +101,9 @@
 
       </p>
     </fieldset>
-
+    
     <p class="action group">
-      <button type="submit" class="button">Send message</button>
+      <%= render "govuk_publishing_components/components/button", text: "Send message" %>
     </p>
   <% end %>
 </div>

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -4,10 +4,12 @@
   <%= form_for :contact, url: contact_govuk_path, as: :post, authenticity_token: false, html: { class: "contact-form" } do |f| %>
     <%= hidden_field_tag 'contact[url]', Plek.new.website_root + contact_govuk_path %>
 
-    <p>This form is for issues to do with the GOV.UK website.</p>
-    <p>You can use it to ask a question, report a problem or suggest an improvement to the GOV.UK team.</p>
-    <p>We can’t reply to you with advice. We don’t have access to information about you held by government departments.</p>
-    <p>If you have a question about a government service or policy, check the <a href="/help">help pages</a> or contact the <a href="/government/organisations">government department</a> directly.</p>
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <p>This form is for issues to do with the GOV.UK website.</p>
+      <p>You can use it to ask a question, report a problem or suggest an improvement to the GOV.UK team.</p>
+      <p>We can’t reply to you with advice. We don’t have access to information about you held by government departments.</p>
+      <p>If you have a question about a government service or policy, check the <a href="/help">help pages</a> or contact the <a href="/government/organisations">government department</a> directly.</p>
+    <% end %>
 
     <%= render partial: "shared/spam_honeypot", locals: { form_name: 'contact' } %>
 
@@ -70,7 +72,10 @@
 
     <fieldset id="contact-details">
       <legend>Do you want a reply?</legend>
-      <p>If you'd like us to get back to you, please leave your details below.</p>
+
+      <%= render "govuk_publishing_components/components/govspeak" do %>
+        <p>If you'd like us to get back to you, please leave your details below.</p>
+      <% end %>
 
       <% if @errors && @errors[:name] %>
         <p class="validation group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,12 +13,7 @@
     <div id="wrapper">
       <main id="content" role="main" class="group category-page">
         <%= render 'govuk_publishing_components/components/breadcrumbs', breadcrumbs: @breadcrumbs %>
-
-        <header class="page-header group">
-          <div class="full-width">
-            <h1><%= yield :title %></h1>
-          </div>
-        </header>
+        <%= render 'govuk_publishing_components/components/title', title: yield(:title) %>
 
         <div class="contact-container full-width group">
           <%= yield %>


### PR DESCRIPTION
We're currently using the `wrapper` layout, which includes a lot of default styles from static. We're getting rid of the `wrapper` layout (in order to get rid of Static altogether). This makes this app use the default (core_layout). Some minor margin changes may happen, those will be fixed once we only use components in this app (like https://github.com/alphagov/feedback/pull/745).

Tech debt trello: https://trello.com/c/Dpe7MWQp