### PR TITLE
Update error messages in survey form

### DIFF
--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -3,11 +3,6 @@ module Contact
     class EmailSurveySignupController < ContactController
       rescue_from SurveyNotifyService::Error, with: :respond_to_notify_error
 
-      DONE_INVALID_EMAIL = "<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2> " +
-        "<p>Enter an email address in the correct format, like name@example.com</p>"
-
-      SERVICE_UNAVAILABLE = "<h2>Sorry, we’re unable to receive your message right now.<h2> " +
-        "<p>If the problem persists, we have other ways for you to provide feedback on the contact page.</p>"
       def create
         data = contact_params.merge(browser_attributes)
         ticket = EmailSurveySignup.new(data)
@@ -41,9 +36,8 @@ module Contact
       end
 
       def respond_to_invalid_submission(ticket)
-        @message = DONE_INVALID_EMAIL.html_safe
         if ajax_request?
-          render json: { message: @message, errors: ticket.errors }, status: :unprocessable_entity
+          render json: { message: I18n.t('controllers.contact.govuk.email_survey_signup.done_invalid_email'), errors: ticket.errors }, status: :unprocessable_entity
         else
           # for now, ignore just discard invalid submissions
           # because the actual form lives in the "frontend" app,
@@ -54,10 +48,9 @@ module Contact
       end
 
       def respond_to_notify_error(exception)
-        @message = SERVICE_UNAVAILABLE.html_safe
         if ajax_request?
           log_exception(exception)
-          render json: { message: @message, errors: exception.cause.message }, status: :service_unavailable
+          render json: { message: I18n.t('controllers.contact.govuk.email_survey_signup.service_unavailable'), errors: exception.cause.message }, status: :service_unavailable
         else
           unable_to_create_ticket_error(exception)
         end

--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -3,6 +3,11 @@ module Contact
     class EmailSurveySignupController < ContactController
       rescue_from SurveyNotifyService::Error, with: :respond_to_notify_error
 
+      DONE_INVALID_EMAIL = "<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2> " +
+        "<p>Enter an email address in the correct format, like name@example.com</p>"
+
+      SERVICE_UNAVAILABLE = "<h2>Sorry, we’re unable to receive your message right now.<h2> " +
+        "<p>If the problem persists, we have other ways for you to provide feedback on the contact page.</p>"
       def create
         data = contact_params.merge(browser_attributes)
         ticket = EmailSurveySignup.new(data)
@@ -36,8 +41,9 @@ module Contact
       end
 
       def respond_to_invalid_submission(ticket)
+        @message = DONE_INVALID_EMAIL.html_safe
         if ajax_request?
-          render json: { message: "email survey sign up failure", errors: ticket.errors }, status: :unprocessable_entity
+          render json: { message: @message, errors: ticket.errors }, status: :unprocessable_entity
         else
           # for now, ignore just discard invalid submissions
           # because the actual form lives in the "frontend" app,
@@ -48,9 +54,10 @@ module Contact
       end
 
       def respond_to_notify_error(exception)
+        @message = SERVICE_UNAVAILABLE.html_safe
         if ajax_request?
           log_exception(exception)
-          render json: { message: "email survey sign up failure", errors: exception.cause.message }, status: :service_unavailable
+          render json: { message: @message, errors: exception.cause.message }, status: :service_unavailable
         else
           unable_to_create_ticket_error(exception)
         end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,4 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
 en:
-  hello: "Hello world"
   activemodel:
     errors:
       models:
@@ -10,3 +6,9 @@ en:
           attributes:
             survey_id:
               is_not_currently_running: "The survey is not currently active"
+  controllers:
+    contact:
+      govuk:
+        email_survey_signup:
+          done_invalid_email: <h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2> <p>Enter an email address in the correct format, like name@example.com</p>
+          service_unavailable: <h2>Sorry, we’re unable to receive your message right now.<h2> <p>If the problem persists, we have other ways for you to provide feedback on the contact page.</p>

--- a/spec/requests/email_survey_signup_request_spec.rb
+++ b/spec/requests/email_survey_signup_request_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
       expect(response.content_type).to eq("application/json")
       json_response = JSON.parse(response.body)
       expect(json_response).to have_key "message"
-      expect(json_response["message"]).to eq "email survey sign up failure"
+      expect(json_response["message"]).to eq "<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2> <p>Enter an email address in the correct format, like name@example.com</p>"
       expect(json_response).to have_key "errors"
     end
 
@@ -70,7 +70,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
       expect(response.content_type).to eq("application/json")
       json_response = JSON.parse(response.body)
       expect(json_response).to have_key "message"
-      expect(json_response["message"]).to eq "email survey sign up failure"
+      expect(json_response["message"]).to eq '<h2>Sorry, we’re unable to receive your message right now.<h2> <p>If the problem persists, we have other ways for you to provide feedback on the contact page.</p>'
       expect(json_response).to have_key "errors"
     end
   end
@@ -91,7 +91,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
       expect(response.content_type).to eq("application/json")
       json_response = JSON.parse(response.body)
       expect(json_response).to have_key "message"
-      expect(json_response["message"]).to eq "email survey sign up failure"
+      expect(json_response["message"]).to eq "<h2>Sorry, we’re unable to send your message as you haven’t given us a valid email address.</h2> <p>Enter an email address in the correct format, like name@example.com</p>"
       expect(json_response).to have_key "errors"
     end
 
@@ -105,7 +105,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
       expect(response.content_type).to eq("application/json")
       json_response = JSON.parse(response.body)
       expect(json_response).to have_key "message"
-      expect(json_response["message"]).to eq "email survey sign up failure"
+      expect(json_response["message"]).to eq '<h2>Sorry, we’re unable to receive your message right now.<h2> <p>If the problem persists, we have other ways for you to provide feedback on the contact page.</p>'
       expect(json_response).to have_key "errors"
     end
   end


### PR DESCRIPTION
## What 
Updates error messages in survey form so they are more helpful.

Error message hint taken from https://design-system.service.gov.uk/patterns/email-addresses/#error-messages

Error message aligns with the feedback component's generic error message: https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/components/feedback.js#L126

## Why
The feedback component in govuk_publishing components was [updated to take into account the 422 HTTP status response](https://github.com/alphagov/govuk_publishing_components/pull/918)

While the error message provided by this app for the "Is there anything wrong with this page?" form was useful, the email survey messages aren't that useful (see below)

## Before
<img width="1033" alt="Screen Shot 2019-06-18 at 13 10 42" src="https://user-images.githubusercontent.com/3758555/59681351-a7232e00-91cb-11e9-9f01-80b1d9c369cf.png">

## After
Invalid Email Address:

<img width="734" alt="Screen Shot 2019-06-18 at 13 05 15" src="https://user-images.githubusercontent.com/3758555/59681377-b4401d00-91cb-11e9-85e1-29374fa949ba.png">

Service Unavailable:

<img width="711" alt="Screen Shot 2019-06-18 at 13 05 04" src="https://user-images.githubusercontent.com/3758555/59681376-b3a78680-91cb-11e9-957b-4be9b9a2e9a2.png">