### PR TITLE
Revert "Bump govuk_publishing_components from 17.21.0 to 19.0.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ else
   gem 'slimmer', '~> 13.1.0'
 end
 
-gem 'govuk_publishing_components', '~> 19.0.0'
+gem 'govuk_publishing_components', '~> 17.21.0'
 
 gem 'plek', '~> 3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (19.0.0)
+    govuk_publishing_components (17.21.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -175,7 +175,7 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.1.1)
     netrc (0.11.0)
-    nio4r (2.5.1)
+    nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     notifications-ruby-client (3.1.0)
@@ -220,7 +220,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.2.0)
+    rails-html-sanitizer (1.1.0)
       loofah (~> 2.2, >= 2.2.2)
     railties (5.2.3)
       actionpack (= 5.2.3)
@@ -247,7 +247,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rouge (3.9.0)
+    rouge (3.7.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -295,8 +295,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    sassc (2.2.0)
+    sassc (2.0.1)
       ffi (~> 1.9)
+      rake
     sassc-rails (2.1.2)
       railties (>= 4.0.0)
       sassc (>= 2.0)
@@ -378,7 +379,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 2.0.0)
   govuk_frontend_toolkit (= 8.2.0)
-  govuk_publishing_components (~> 19.0.0)
+  govuk_publishing_components (~> 17.21.0)
   govuk_test
   invalid_utf8_rejector
   notifications-ruby-client


### PR DESCRIPTION
Reverts alphagov/feedback#809

This gem version updates Feedback to the latest version of GOVUK Frontend, which introduces a few problems with font-size and styling which need to be addressed. These are being addressed as part of https://github.com/alphagov/feedback/pull/803.