### PR TITLE
Update govuk_publishing_components to v20.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ else
   gem 'slimmer', '~> 13.1.0'
 end
 
-gem 'govuk_publishing_components', '~> 20.0.0'
+gem 'govuk_publishing_components', '~> 20.5.1'
 
 gem 'plek', '~> 3.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,13 +117,9 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (9.0.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
-    govuk_publishing_components (20.0.0)
+    govuk_publishing_components (20.5.1)
       gds-api-adapters
       govuk_app_config
-      govuk_frontend_toolkit
       kramdown
       plek
       rails (>= 5.0.0.1)
@@ -378,7 +374,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers
   govuk-lint
   govuk_app_config (~> 2.0.0)
-  govuk_publishing_components (~> 20.0.0)
+  govuk_publishing_components (~> 20.5.1)
   govuk_test
   invalid_utf8_rejector
   notifications-ruby-client

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -2,12 +2,10 @@
   <%= form_for :contact, url: contact_govuk_path, as: :post, authenticity_token: false, html: { class: "contact-form" } do |f| %>
     <%= hidden_field_tag 'contact[url]', Plek.new.website_root + contact_govuk_path %>
 
-    <%= render "govuk_publishing_components/components/govspeak" do %>
-      <p>This form is for issues to do with the GOV.UK website.</p>
-      <p>You can use it to ask a question, report a problem or suggest an improvement to the GOV.UK team.</p>
-      <p>We can’t reply to you with advice. We don’t have access to information about you held by government departments.</p>
-      <p>If you have a question about a government service or policy, check the <a href="/help">help pages</a> or contact the <a href="/government/organisations">government department</a> directly.</p>
-    <% end %>
+    <p class="govuk-body">This form is for issues to do with the GOV.UK website.</p>
+    <p class="govuk-body">You can use it to ask a question, report a problem or suggest an improvement to the GOV.UK team.</p>
+    <p class="govuk-body">We can’t reply to you with advice. We don’t have access to information about you held by government departments.</p>
+    <p class="govuk-body">If you have a question about a government service or policy, check the <a class="govuk-link" href="/help">help pages</a> or contact the <a class="govuk-link" href="/government/organisations">government department</a> directly.</p>
 
     <%= render partial: "shared/spam_honeypot", locals: { form_name: 'contact' } %>
     <% if @errors %>
@@ -54,14 +52,10 @@
     <fieldset class="govuk-fieldset govuk-!-margin-top-6">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What are the details?</legend>
         <span class="govuk-hint gem-c-hint">For example if you were searching for something, what did you type into the search box?</span>
-
-        <%= render "govuk_publishing_components/components/govspeak", {} do %>
-          <div class="application-notice help-notice">
-            <p class="warning-message">
-              Don’t include personal or financial information, for example your National Insurance number or credit card details.
-            </p>
-          </div>
-        <% end %>
+        
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: "Don’t include personal or financial information, for example your National Insurance number or credit card details."
+        } %>
 
         <label for="textdetails" class="visuallyhidden">Detail</label>
         <% if @errors && @errors[:textdetails] %>
@@ -76,9 +70,7 @@
     <fieldset class="govuk-fieldset govuk-!-margin-top-6">
       <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">Do you want a reply?</legend>
 
-      <%= render "govuk_publishing_components/components/govspeak" do %>
-        <p>If you'd like us to get back to you, please leave your details below.</p>
-      <% end %>
+      <p class="govuk-body">If you'd like us to get back to you, please leave your details below.</p>
       <% if @errors && @errors[:name] %>
       <div class="govuk-form-group govuk-form-group--error">
       <% else %>


### PR DESCRIPTION
Additionally remove govspeak usage and replace with a warning component as well paragraph and link css classes

Main reason is that images that were present in frontend_toolkit that govspeak relied on are not present, breaking the govspeak warning component.

Also using the publishing component is better 😉 

<img width="538" alt="Screen Shot 2019-09-14 at 13 54 40" src="https://user-images.githubusercontent.com/3758555/64908533-5d2de380-d6f9-11e9-9d25-c9e12afd3dfb.png">

URL to check:  https://govuk-feedback-pr-822.herokuapp.com/contact/govuk