### PR TITLE
WIP: Rescue 403 errors from content store

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ require "gds_api/exceptions"
 class ApplicationController < ActionController::Base
   rescue_from SpamError, with: :robot_script_submission_detected
   rescue_from GdsApi::BaseError, with: :unable_to_create_ticket_error
+  rescue_from GdsApi::HTTPForbidden, with: :error_403
 
   include Slimmer::Template
 
@@ -37,6 +38,10 @@ protected
         render json: { status: "error", message: response }, status: 503
       end
     end
+  end
+
+  def error_403(exception)
+    head(:forbidden)
   end
 
   def hide_report_a_problem_form_in_response

--- a/spec/controllers/contact_controller_spec.rb
+++ b/spec/controllers/contact_controller_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Contact::ContactController, type: :controller do
+  context "when content store is returning a 403" do
+    before do
+      # Visiting https://draft-origin.publishing.service.gov.uk/contact/govuk
+      # with a token cookie exhibits the issue
+      stub_request(:get, "#{Plek.find('content-store')}/content/contact").
+        to_return(status: 403, headers: {})
+    end
+
+    it "should return 403" do
+      get :new, params: {} # TBC
+
+      expect(response.status).to eq 403
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/T1WbCkTR/171-unauthenticated-user-accessing-a-feedback-page-with-step-by-step-token-is-directed-to-sign-on
Follows on from: [RFC 113: Expanding draft access for unauthenticated users to allow multi-page fact checks](https://github.com/alphagov/govuk-rfcs/blob/master/rfc-113-expanding-draft-access-for-unauthenticated-users.md)

## What's changed and why?

At the moment `feedback` is throwing a 500 when it receives
an error code it doesn't recognise from content-store. That means
that users are shown a "Problem has occurred" page.

We need to handle this error properly so that in the case of a
403, the user will be properly routed to signon and asked to login
if there is any form of access limiting on the content item (e.g.
hosted on draft stack, access limited to organisation)