### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <%=  stylesheet_link_tag 'feedback', integrity: true, crossorigin: 'anonymous' %>
-    <%=  stylesheet_link_tag 'print.css', media: 'print', integrity: true, crossorigin: 'anonymous' %>
+    <%=  stylesheet_link_tag 'feedback', integrity: false %>
+    <%=  stylesheet_link_tag 'print.css', media: 'print', integrity: false %>
     <!--[if IE 6]><%= stylesheet_link_tag "feedback-ie6.css" %><![endif]-->
-    <%=  javascript_include_tag 'feedback', integrity: true, crossorigin: 'anonymous' %>
+    <%=  javascript_include_tag 'feedback', integrity: false %>
     <title><%= yield :title %></title>
     <%= yield :section_meta_tags %>
   </head>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)