### PR TITLE
Create test-dependencies.js to replace live static assets 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "rack_strip_client_ip", "0.0.2"
 gem "rails", "5.2.3"
 gem "sass", "~> 3.7.4"
 gem "sass-rails", "~> 5.0.7"
-gem "slimmer", "~> 13.3.0"
+gem "slimmer", "~> 15.0"
 gem "uglifier", "~> 4.2.0"
 gem "valid_email", "~> 0.1.3"
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,38 +1,20 @@
 source "https://rubygems.org"
 
-gem "rails", "5.2.3"
-
-if ENV["SLIMMER_DEV"]
-  gem "slimmer", path: "../slimmer"
-else
-  gem "slimmer", "~> 13.3.0"
-end
-
-gem "govuk_publishing_components", "~> 21.51.0"
-
-gem "plek", "~> 3.0.0"
-
-gem "valid_email", "~> 0.1.3"
-
-gem "invalid_utf8_rejector"
-gem "rack_strip_client_ip", "0.0.2"
-
 gem "asset_bom_removal-rails", "~> 1.0.2"
+gem "gds-api-adapters", "63.6.0"
+gem "google-api-client", "~> 0.38"
+gem "govuk_app_config", "~> 2.1.2"
+gem "govuk_publishing_components", "~> 21.51.0"
+gem "invalid_utf8_rejector"
+gem "notifications-ruby-client"
+gem "plek", "~> 3.0.0"
+gem "rack_strip_client_ip", "0.0.2"
+gem "rails", "5.2.3"
 gem "sass", "~> 3.7.4"
 gem "sass-rails", "~> 5.0.7"
+gem "slimmer", "~> 13.3.0"
 gem "uglifier", "~> 4.2.0"
-
-gem "google-api-client", "~> 0.38"
-
-gem "notifications-ruby-client"
-
-if ENV["API_DEV"]
-  gem "gds-api-adapters", path: "../gds-api-adapters"
-else
-  gem "gds-api-adapters", "63.6.0"
-end
-
-gem "govuk_app_config", "~> 2.1.2"
+gem "valid_email", "~> 0.1.3"
 
 group :development, :test do
   gem "ci_reporter_rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,7 +309,7 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    slimmer (13.3.0)
+    slimmer (15.0.0)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -381,7 +381,7 @@ DEPENDENCIES
   sass (~> 3.7.4)
   sass-rails (~> 5.0.7)
   shoulda-matchers (~> 4.3.0)
-  slimmer (~> 13.3.0)
+  slimmer (~> 15.0)
   uglifier (~> 4.2.0)
   valid_email (~> 0.1.3)
   webmock (~> 3.8.3)

--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,0 +1,3 @@
+// This file contains dependencies that are only needed when running in a test
+// environment. In the dev and live environment these are provided by static.
+//= require govuk_publishing_components/dependencies

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
     <%=  stylesheet_link_tag 'application', integrity: false %>
     <%=  stylesheet_link_tag 'print.css', media: 'print', integrity: false %>
     <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
+    <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
     <%=  javascript_include_tag 'application', integrity: false %>
     <title><%= yield :title %></title>
     <%= yield :section_meta_tags %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.precompile += %w[print.css]
+Rails.application.config.assets.precompile += %w[print.css test-dependencies.js]


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

The tests for this app were failing after GOV.UK's assets switched from
the assets hostname to www. This was because slimmer was actually
embedding links to production GOV.UK assets which were symlinked to the
latest ones. Once the assets changed path then the tests broke.

Since it is good practice for tests to be isolated I've created a
test-dependencies.js file which loads in the basic slimmer dependencies
from govuk_publishing_components. This has the advantage that this test
suite no longer has external network requirement, but does have the
disadvantage that the JS isn't the same. This trade-off seems reasonable
since there was never anything particularly realistic about the slimmer
test template [1] and it's mostly luck that it matches production.

[1]: https://github.com/alphagov/slimmer/blob/master/lib/slimmer/test_templates/wrapper.html