### PR TITLE
Use individual component JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,11 @@
 //= require vendor/jquery.inputevent
-//= require govuk_publishing_components/all_components
+//= require govuk_publishing_components/lib
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/details
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/radio
 
 (function(){
   "use strict";
@@ -42,7 +48,7 @@
     var charNoun = 'character' + ((remainingNumber === -1 || remainingNumber === 1) ? '' : 's')
     var displayNumber = Math.abs(remainingNumber)
     $(counterId).html((displayNumber) + ' ' + charNoun + ' ' + charVerb + " (limit is " + maxLength + " characters)");
-    
+
     // remove aria attributes when users start typing
     $(counterId).removeAttr('aria-live aria-atomic')
 


### PR DESCRIPTION
Update feedback to import the Javascript for only the components it is using, instead of all components, as [documented here](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/install-and-use.md#import-javascript-for-individual-components).

Note: despite recent changes to the suggested sass feature, the suggested sass for calculators remains unchanged.

## Filesize comparison

<img width="436" alt="Screenshot 2020-06-17 at 10 52 55" src="https://user-images.githubusercontent.com/861310/84883969-1ce50280-b089-11ea-856b-85a770e00f7f.png">

JS before: **477 KB**

<img width="435" alt="Screenshot 2020-06-17 at 10 54 37" src="https://user-images.githubusercontent.com/861310/84884020-24a4a700-b089-11ea-8a5a-73bea265754c.png">

JS after: **295 KB**


Trello card: https://trello.com/c/GWttlBxs/228-upgrade-applications-to-use-individual-component-sass

