### PR TITLE
Change API keys for Notify account

### DIFF
--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -60,7 +60,7 @@ class EmailSurveySignup
       # this is our default template for emails, a future version might
       # want to make this configurable per survey, but then we'd almost
       # certainly need to make the `personalisation` parts configurable too
-      template_id: "8fe8ab4f-a6ac-44a1-9d8b-f611a493231b",
+      template_id: template_id,
       email_address: email_address,
       personalisation: {
         # Note that notify will error if we don't supply all the keys the
@@ -73,6 +73,10 @@ class EmailSurveySignup
   end
 
 private
+
+  def template_id
+    @template_id ||= ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id")
+  end
 
   def survey_source_is_relative
     errors.add(:survey_source, :is_not_a_relative_url) unless UrlNormaliser.valid_url?(survey_source, relative_only: true)

--- a/config/initializers/survey_notify_service.rb
+++ b/config/initializers/survey_notify_service.rb
@@ -5,7 +5,7 @@ api_key = if Rails.env.test?
             # won't break when interrogating it
             "testkey1-12345678-90ab-cdef-1234-567890abcdef-12345678-90ab-cdef-1234-567890abcdef"
           else
-            ENV["SURVEY_NOTIFY_SERVICE_API_KEY"]
+            ENV["GOVUK_NOTIFY_API_KEY"]
           end
 
 Rails.application.config.survey_notify_service = SurveyNotifyService.new(api_key)

--- a/docs/email_survey_signups.md
+++ b/docs/email_survey_signups.md
@@ -15,13 +15,13 @@ that we don't send emails when the survey has closed.  Unlike their counterparts
 in static they do not have match rules on the path - response that gets past an
 `survey_id` check and is in the `active?` time period will be sent an email.
 
-The email is sent using GOV.UK Notify using the "GOV.UK Surveys" service and a
+The email is sent using GOV.UK Notify using the "GOV.UK Public" service and a
 hardcoded email template (name: `email_survey_signup`, id: `8fe8ab4f-a6ac-44a1-9d8b-f611a493231b`)
 that belongs to that service.  This means that all running instances must use
 API keys for the same service or the template won't exist.  The API key is
 provided with the env var:
 
-    SURVEY_NOTIFY_SERVICE_API_KEY
+    GOVUK_NOTIFY_API_KEY
 
 Deployed environments have this filled in via puppet and our standard mechanism
 for handling keys.  On the GOV.UK dev vm you'll want to join the service on

--- a/docs/email_survey_signups.md
+++ b/docs/email_survey_signups.md
@@ -15,13 +15,13 @@ that we don't send emails when the survey has closed.  Unlike their counterparts
 in static they do not have match rules on the path - response that gets past an
 `survey_id` check and is in the `active?` time period will be sent an email.
 
-The email is sent using GOV.UK Notify using the "GOV.UK Public" service and a
-hardcoded email template (name: `email_survey_signup`, id: `8fe8ab4f-a6ac-44a1-9d8b-f611a493231b`)
-that belongs to that service.  This means that all running instances must use
-API keys for the same service or the template won't exist.  The API key is
-provided with the env var:
+The email is sent using GOV.UK Notify using the "GOV.UK Public" service, with a distinct
+service running per environment. The API key is provided with the env var:
 
     GOVUK_NOTIFY_API_KEY
+
+The email template is provided with the env var:
+    GOVUK_NOTIFY_TEMPLATE_ID
 
 Deployed environments have this filled in via puppet and our standard mechanism
 for handling keys.  On the GOV.UK dev vm you'll want to join the service on

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe EmailSurveySignup, type: :model do
     subject { email_survey_signup.to_notify_params }
 
     it "includes the default template_id" do
-      expect(subject[:template_id]).to eq "8fe8ab4f-a6ac-44a1-9d8b-f611a493231b"
+      expect(subject[:template_id]).to eq "fake-test-template-id"
     end
 
     it "includes the email address" do


### PR DESCRIPTION
Feedback uses Notify to send e-mails to users who have signed up for surveys. We are creating different Notify services for each environment, in line with other GOV.UK applications.

The environment variable name for the API key has been changed, and the email template ID is now also distinct across different environments.

[Related puppet pr](https://github.com/alphagov/govuk-puppet/pull/10557)
[Trello](https://trello.com/c/zs2mHfAM/2061-3-feedback-app-uses-its-own-notify-account)