### PR TITLE
Add email_reply_to _id email address Notify ID's for surveys

### DIFF
--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -69,10 +69,15 @@ class EmailSurveySignup
         survey_url: survey_url,
       },
       reference: "email-survey-signup-#{object_id}",
+      email_reply_to_id: reply_to_id,
     }
   end
 
 private
+
+  def reply_to_id
+    @reply_to_id ||= ENV.fetch("GOVUK_NOTIFY_REPLY_TO_ID", "fake-test-reply-to-id")
+  end
 
   def template_id
     @template_id ||= ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id")

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -170,6 +170,10 @@ RSpec.describe EmailSurveySignup, type: :model do
       expect(subject[:template_id]).to eq "fake-test-template-id"
     end
 
+    it "includes the default reply_to_id" do
+      expect(subject[:email_reply_to_id]).to eq "fake-test-reply-to-id"
+    end
+
     it "includes the email address" do
       expect(subject[:email_address]).to eq "i_like_taking_surveys@example.com"
     end


### PR DESCRIPTION
This adds an email_reply_to_id email address for survey emails sent by the Notify service

[Related puppet PR](https://github.com/alphagov/govuk-puppet/pull/10569)

[Trello](https://trello.com/c/zs2mHfAM/2061-3-feedback-app-uses-its-own-notify-account)