### PR TITLE
Remove asset-bom-removal gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source "https://rubygems.org"
 
 gem "rails", "6.0.3.2"
 
-gem "asset_bom_removal-rails"
 gem "gds-api-adapters"
 gem "google-api-client"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,9 +58,6 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    asset_bom_removal-rails (1.0.2)
-      rails (>= 4.2)
-      sass (> 3.4)
     ast (2.4.1)
     brakeman (4.8.2)
     builder (3.2.4)
@@ -80,7 +77,7 @@ GEM
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
     coderay (1.1.3)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.6)
@@ -380,7 +377,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  asset_bom_removal-rails
   ci_reporter_rspec
   gds-api-adapters
   google-api-client


### PR DESCRIPTION
We were running into this error https://github.com/alphagov/whitehall/issues/4724
which is actually caused by the asset-bom-removal gem

To work around the issue with sassc and unquote the accepted solution has been to
set css_compressor to nil and then use sass_style to achieve a similar effect.
However the gem forces the css_compressor back to :sass thus breaking again on asset compilation.

Removing the gem fixes this and the gem itself does not seem to be necessary since
it was introduced to fix issues in Firefox 52 and the latest Firefox version is
78