### PR TITLE
Add name and email autocomplete values for govuk contact view

### DIFF
--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -107,6 +107,7 @@
         },
         name: "contact[name]",
         id: "name",
+        autocomplete: "name",
         value: @old ? @old[:name] : '',
         error_message: name_error
       } %>
@@ -124,6 +125,7 @@
         name: "contact[email]",
         type: "email",
         id: "email",
+        autocomplete: "email",
         value: @old ? @old[:email] : '',
         error_message: email_error
       } %>


### PR DESCRIPTION
## What

Adds the autocomplete attribute to the name and email fields on the [govuk contact form](https://www.gov.uk/contact/govuk).

## Why

This is part of the ongoing govuk a11y work, specifically this change ensures that the contact form is compliant with [WCAG SC: 1.3.5](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html).

**Card:** https://trello.com/c/773Yfi5Z/298-contact-form-missing-autocomplete-attribute