### PR TITLE
Disable CSRF protection

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,8 @@ class ApplicationController < ActionController::Base
 
   include Slimmer::Template
 
+  skip_forgery_protection
+
   if ENV["BASIC_AUTH_USERNAME"]
     http_basic_authenticate_with(
       name: ENV.fetch("BASIC_AUTH_USERNAME"),

--- a/app/controllers/contact/govuk/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk/problem_reports_controller.rb
@@ -17,9 +17,7 @@ class Contact::Govuk::ProblemReportsController < ContactController
     ticket = ReportAProblemTicket.new(attributes)
 
     if ticket.valid?
-      # rubocop:disable Rails/SaveBang
       ticket.save
-      # rubocop:enable Rails/SaveBang
 
       hide_report_a_problem_form_in_response
       @message = DONE_OK_TEXT.html_safe

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -60,9 +60,7 @@ private
   end
 
   def respond_to_valid_submission(ticket)
-    # rubocop:disable Rails/SaveBang
     ticket.save
-    # rubocop:enable Rails/SaveBang
     confirm_submission
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,13 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
     <%=  stylesheet_link_tag 'application', integrity: false %>
     <%=  stylesheet_link_tag 'print.css', media: 'print', integrity: false %>
-    <!--[if IE 6]><%= stylesheet_link_tag "application-ie6.css" %><![endif]-->
-    <%= javascript_include_tag "test-dependencies" if Rails.env.test? %>
-    <%=  javascript_include_tag 'application', integrity: false %>
+    <!--[if IE 6]><%= stylesheet_link_tag 'application-ie6.css' %><![endif]-->
+    <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
+    <%= javascript_include_tag 'application', integrity: false %>
     <title><%= yield :title %></title>
     <%= yield :section_meta_tags %>
   </head>

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,8 +25,6 @@ module Feedback
     # when router is proxying to this app but asset proxying isn't set up.
     config.asset_host = ENV["ASSET_HOST"]
 
-    config.filter_parameters += %i[password name email email_confirmation textdetails what_doing what_wrong]
-
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,13 +13,12 @@ module Feedback
     config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
-
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    config.action_dispatch.rack_cache = nil
 
+    # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
     config.assets.enabled = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,11 +21,6 @@ module Feedback
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 
-    config.assets.enabled = true
-    config.assets.precompile += %w[application-ie6.css]
-    config.assets.prefix = "/assets/feedback"
-    config.assets.version = "1.0"
-
     # allow overriding the asset host with an enironment variable, useful for
     # when router is proxying to this app but asset proxying isn't set up.
     config.asset_host = ENV["ASSET_HOST"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,8 +25,6 @@ module Feedback
     # when router is proxying to this app but asset proxying isn't set up.
     config.asset_host = ENV["ASSET_HOST"]
 
-    config.encoding = "utf-8"
-
     config.filter_parameters += %i[password name email email_confirmation textdetails what_doing what_wrong]
 
     # Using a sass css compressor causes a scss file to be processed twice

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ module Feedback
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    # Disable CSRF protection by default as page is cached in the CDN.
+    config.action_controller.default_protect_from_forgery = false
 
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,9 +17,6 @@ module Feedback
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    # Disable CSRF protection by default as page is cached in the CDN.
-    config.action_controller.default_protect_from_forgery = false
-
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,8 +22,9 @@ Rails.application.configure do
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
 
-  # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  # Enable request forgery protection in test environment.
+  # This is so the tests fail if CSRF protection is enabled by default.
+  config.action_controller.allow_forgery_protection = true
 
   config.action_mailer.perform_caching = false
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,12 +3,17 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = "1.0"
 
+# Path within public/ where assets are compiled to
+Rails.application.config.assets.prefix = "/assets/feedback"
+
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
-# Add Yarn node_modules folder to the asset load path.
-# Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[print.css test-dependencies.js]
+Rails.application.config.assets.precompile += %w[
+  application-ie6.css
+  print.css
+  test-dependencies.js
+]

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += %i[
+  password
+  name
+  email
+  email_confirmation
+  textdetails
+  what_doing
+  what_wrong
+]

--- a/spec/models/assisted_digital_feedback_spec.rb
+++ b/spec/models/assisted_digital_feedback_spec.rb
@@ -22,9 +22,7 @@ RSpec.describe AssistedDigitalFeedback, type: :model do
     context "#save" do
       it "sends the item to be stored in the google spreadsheet as row data" do
         expect(Rails.application.config.assisted_digital_spreadsheet).to receive(:store).with(subject.as_row_data)
-        # rubocop:disable Rails/SaveBang
         subject.save
-        # rubocop:enable Rails/SaveBang
       end
 
       it "should raise an exception if the google spreadsheet communication doesn't work" do
@@ -40,9 +38,7 @@ RSpec.describe AssistedDigitalFeedback, type: :model do
     context "#save" do
       it "does not send the options to be stored in the google spreadsheet" do
         expect(Rails.application.config.assisted_digital_spreadsheet).not_to receive(:store)
-        # rubocop:disable Rails/SaveBang
         subject.save
-        # rubocop:enable Rails/SaveBang
       end
     end
   end

--- a/spec/models/contact_ticket_spec.rb
+++ b/spec/models/contact_ticket_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe ContactTicket, type: :model do
       bad_actors.each do |bad_actor|
         bad_ticket = ContactTicket.new valid_named_ticket_details.merge(name: "Bad Robot", email: bad_actor)
         expect(Rails.application.config.support).to_not receive(:create_named_contact)
-        # rubocop:disable Rails/SaveBang
         bad_ticket.save
-        # rubocop:enable Rails/SaveBang
       end
     end
   end

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -25,9 +25,7 @@ RSpec.describe EmailSurveySignup, type: :model do
     context "#save" do
       it "sends an email to the email address using GOV.UK notify" do
         expect(Rails.application.config.survey_notify_service).to receive(:send_email).with(subject)
-        # rubocop:disable Rails/SaveBang
         subject.save
-        # rubocop:enable Rails/SaveBang
       end
 
       it "should raise an exception if the GOV.UK notify call doesn't work" do
@@ -43,9 +41,7 @@ RSpec.describe EmailSurveySignup, type: :model do
     context "#save" do
       it "does not send an email using GOV.UK notify" do
         expect(Rails.application.config.survey_notify_service).not_to receive(:send_email)
-        # rubocop:disable Rails/SaveBang
         subject.save
-        # rubocop:enable Rails/SaveBang
       end
     end
   end

--- a/spec/models/multi_ticket_spec.rb
+++ b/spec/models/multi_ticket_spec.rb
@@ -77,9 +77,7 @@ RSpec.describe MultiTicket, type: :model do
         expect(service_ticket).to receive(:save)
         expect(assisted_digital_ticket).to receive(:save)
 
-        # rubocop:disable Rails/SaveBang
         subject.save
-        # rubocop:enable Rails/SaveBang
       end
 
       it "it does not continue to the next ticket and raises the error if one of the tickets errors out while saving" do


### PR DESCRIPTION
As the feedback form is cached in the CDN we can't use cookie-based sessions for CSRF protection so disable it by default but allow it in the test environment to ensure it doesn't get re-enabled by mistake.

CSRF protection was accidentally re-enabled during the upgrade from Rails 5.1 to 6.0 because the setting was added to ActionController::Base and the protect_from_forgery line removed from ApplicationController.