### PR TITLE
Restore asset compress after Rails 6 upgrade

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,6 +21,9 @@ Rails.application.configure do
 
   config.serve_static_files = false
 
+  # Compress JS using a preprocessor.
+  config.assets.js_compressor = :uglifier
+
   # Rather than use a CSS compressor, use the SASS style to perform compression.
   config.sass.style = :compressed
   config.sass.line_comments = false


### PR DESCRIPTION
## What

Changes to `production.rb` to restore asset compression to previous output.

## Why

* The upgrade to Rails 6 disabled JS compression because it now defaults to using webpack.

## Visual differences

None.