### PR TITLE
Fix call to index_with when creating ticket details

### DIFF
--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -34,8 +34,8 @@ class ReportAProblemTicket < Ticket
 private
 
   def ticket_details
-    %i[what_wrong what_doing path user_agent javascript_enabled referrer source page_owner].index_with({}) do |field, details|
-      details[field] = send(field)
+    %i[what_wrong what_doing path user_agent javascript_enabled referrer source page_owner].index_with do |field|
+      send(field)
     end
   end
 end


### PR DESCRIPTION
This PR fixes the call to `index_with` when creating `ticket_details` for the _Report a problem_ tickets.

Previously, `index_with` was being called with an empty hash and a block including the variable for the hash. This was a change in the Rails 6 upgrade, whereas previously we were using `each_with_object`. This change may have been made as a result of a Rubocop warning to use `index_with` instead of `each_with_object`, but this has only been applied to the method name and not to the parameters and the block that it's being called with.

See the [Rubocop docs](https://www.rubydoc.info/gems/rubocop-rails/2.5.2/RuboCop/Cop/Rails/IndexWith) for more details.

[Trello card](https://trello.com/c/4vCX2BxA/975-investigate-nomethoderror)

Co-Authored-By: Graham Lewis <graham.lewis@digital.cabinet-office.gov.uk>