### PR TITLE
Add regression test for #1073

### DIFF
--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -1,8 +1,30 @@
 require "rails_helper"
 
 RSpec.describe ReportAProblemTicket, type: :model do
+  let(:support_api) { Rails.application.config.support_api }
+
   def ticket(params = {})
     ReportAProblemTicket.new(params)
+  end
+
+  it "should create a ticket" do
+    allow(support_api).to receive(:create_problem_report).and_return(true)
+
+    expect(ticket(
+      what_wrong: "The page is broken",
+      what_doing: "Submitting a form",
+    ).save).to be_truthy
+
+    expect(support_api).to have_received(:create_problem_report).with(
+      javascript_enabled: false,
+      page_owner: nil,
+      path: nil,
+      referrer: nil,
+      source: nil,
+      user_agent: nil,
+      what_wrong: "The page is broken",
+      what_doing: "Submitting a form",
+    )
   end
 
   it "should validate the presence of 'what_wrong'" do


### PR DESCRIPTION
There was no 'happy path' test for the ReportAProblemTicket class so the issue addressed in #1073 wasn't caught until after deployment. This commit adds a regression test to ensure that the hash sent to the create_problem_report method is constructed correctly.