### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,8 +4,6 @@ library("govuk")
 
 node {
   govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    sassLint: false,
     brakeman: true,
   )
 }


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82