### PR TITLE
Update feedback response styles

### DIFF
--- a/app/controllers/contact/govuk/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk/problem_reports_controller.rb
@@ -1,9 +1,9 @@
 class Contact::Govuk::ProblemReportsController < ContactController
-  DONE_OK_TEXT = "<h2>Thank you for your help.</h2> " \
-    "<p>If you have more extensive feedback, " \
-    "please visit the <a href='/contact'>contact page</a>.</p>".freeze
-  DONE_INVALID_TEXT = "<h2>Sorry, we're unable to send your message as you haven't given us any information.</h2> " \
-    "<p>Please tell us what you were doing or what went wrong.</p>".freeze
+  DONE_OK_TEXT = "<h1 class='govuk-heading-l'>Thank you for your help.</h1> " \
+    "<p class='govuk-body'>If you have more extensive feedback, " \
+    "please visit the <a class='govuk-link' href='/contact'>contact page</a>.</p>".freeze
+  DONE_INVALID_TEXT = "<h1 class='govuk-heading-l'>Sorry, we're unable to send your message as you haven't given us any information.</h1> " \
+    "<p class='govuk-body'>Please tell us what you were doing or what went wrong.</p>".freeze
 
   def create
     attributes = params.merge(technical_attributes)

--- a/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
+++ b/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Contact::Govuk::ProblemReportsController, type: :controller do
         it "should render the thankyou template assigning the message string" do
           do_submit
           expect(response).to render_template("thankyou")
-          expect(assigns[:message]).to eq("<h2>Thank you for your help.</h2> <p>If you have more extensive feedback, please visit the <a href='/contact'>contact page</a>.</p>")
+          expect(assigns[:message]).to eq("<h1 class='govuk-heading-l'>Thank you for your help.</h1> <p class='govuk-body'>If you have more extensive feedback, please visit the <a class='govuk-link' href='/contact'>contact page</a>.</p>")
           expect(assigns[:message]).to be_html_safe
         end
 
@@ -121,7 +121,7 @@ RSpec.describe Contact::Govuk::ProblemReportsController, type: :controller do
         it "should return json indicating success" do
           do_submit
           data = JSON.parse(response.body)
-          expect(data).to eq("status" => "success", "message" => "<h2>Thank you for your help.</h2> <p>If you have more extensive feedback, please visit the <a href='/contact'>contact page</a>.</p>")
+          expect(data).to eq("status" => "success", "message" => "<h1 class='govuk-heading-l'>Thank you for your help.</h1> <p class='govuk-body'>If you have more extensive feedback, please visit the <a class='govuk-link' href='/contact'>contact page</a>.</p>")
         end
 
         it "should return json indicating failure when ticket creation fails" do


### PR DESCRIPTION
When JavaScript is disabled we render a response page after users leave feedback on a page. We seem to have neglected the styles on this page so far so we're now updating it to use standard styles.

Follow up on https://github.com/alphagov/govuk_publishing_components/pull/1900 to improve no-js experience when giving feedback.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1440" alt="feedback-before" src="https://user-images.githubusercontent.com/788096/106938705-3c639500-6717-11eb-8aab-803e3cfb946f.png">


</td><td valign="top">

<img width="1284" alt="feedback-after" src="https://user-images.githubusercontent.com/788096/106938715-3f5e8580-6717-11eb-8793-c9be4cee92b4.png">


</td></tr>
</table>
