### PR TITLE
Replace contact list with document list component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/character-count";
 @import "govuk_publishing_components/components/details";
+@import "govuk_publishing_components/components/document-list";
 @import "govuk_publishing_components/components/error-message";
 @import "govuk_publishing_components/components/error-summary";
 @import "govuk_publishing_components/components/feedback";
@@ -18,7 +19,3 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/textarea";
 @import "govuk_publishing_components/components/title";
 @import "govuk_publishing_components/components/warning-text";
-
-.app-link-as-heading {
-  @include govuk-font($size:24, $weight: bold, $line-height: 1.8);
-}

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -46,6 +46,7 @@ class ContactController < ApplicationController
   end
 
 private
+
   def filtered_links(array)
     array.map do |item|
       {

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -2,12 +2,13 @@ require "slimmer/headers"
 
 class ContactController < ApplicationController
   include Slimmer::Headers
+  include ApplicationHelper
 
   before_action :set_cache_control, only: %i[new index]
 
   def index
-    @popular_links = CONTACT_LINKS.popular
-    @long_tail_links = CONTACT_LINKS.long_tail
+    @popular_links = filtered_links(CONTACT_LINKS.popular)
+    @long_tail_links = filtered_links(CONTACT_LINKS.long_tail)
     @breadcrumbs = [breadcrumbs.first]
   end
 
@@ -45,6 +46,19 @@ class ContactController < ApplicationController
   end
 
 private
+  def filtered_links(array)
+    array.map do |item|
+      {
+        link: {
+          text: item["Title"],
+          path: item["URL"],
+          description: item["Description"],
+          full_size_description: true,
+          rel: external_link?(item["URL"]) ? "external" : "",
+        },
+      }
+    end
+  end
 
   def breadcrumbs
     [

--- a/app/views/contact/_contact-link.html.erb
+++ b/app/views/contact/_contact-link.html.erb
@@ -1,4 +1,0 @@
-<li>
-  <%= link_to(link["Title"], link["URL"], class: "govuk-link app-link-as-heading", rel: external_link?(link["URL"]) ? 'external' : '') %>
-  <p class="govuk-body"><%= link["Description"] %></p>
-</li>

--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title do "Find contact details for services" end %>
-  <ul id="popular-links" class="govuk-list">
-    <%= render partial: "contact-link", collection: @popular_links, as: :link %>
-  </ul>
+  <%= render "govuk_publishing_components/components/document_list", {
+    items: @popular_links
+  } %>
 
   <%= render "govuk_publishing_components/components/details", {
     title: "More topics"
   } do %>
-    <ul class="govuk-list">
-      <%= render partial: "contact-link", collection: @long_tail_links, as: :link %>
-    </ul>
+    <%= render "govuk_publishing_components/components/document_list", {
+      items: @long_tail_links
+    } %>
   <% end %>
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 <p class="govuk-body">Use the <a class="govuk-link" href="/contact/govuk">GOV.UK form</a> to send your questions or comments about the website.</p>

--- a/spec/requests/interstitial_page_spec.rb
+++ b/spec/requests/interstitial_page_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Interstitial page", type: :request do
   end
 
   it "displays popular contact links" do
-    within "#popular-links" do
+    within first(".gem-c-document-list") do
       CONTACT_LINKS.popular.each do |link|
         expect(page).to have_link(link["Title"], href: link["URL"])
       end


### PR DESCRIPTION
## What
Replaces the contacts list markup with the [document list component](https://components.publishing.service.gov.uk/component-guide/document_list).

## Why
This is part of work done by the govuk accessibility team to replaces bespoke markup with instances of our components gem where possible. Replacing the bespoke markup present on the feedback index with one of our components allows us to easily roll out new changes and bug fixes to all apps without the risk of tech debt building up.

Whilst not a replication of the current design, the document list is a common pattern across govuk and we in the team have assessed that impact to users will be minimal.

[Card](https://trello.com/c/Hx76hGvU/554-update-feedback-app-to-use-components)

## Visual changes
### Before
![Screenshot 2021-02-09 at 17 15 46](https://user-images.githubusercontent.com/64783893/107401121-78716e00-6afa-11eb-9a47-3a2c482f050b.png)

### After
![Screenshot 2021-02-09 at 17 15 29](https://user-images.githubusercontent.com/64783893/107401134-7c9d8b80-6afa-11eb-8b56-bb5d84ae419e.png)
