### PR TITLE
Retain url in GOV.UK feedback form when invalid

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -81,7 +81,9 @@
     specificPage = specificPage.replace(emailPattern, '[email]')
 
     // Preopulate specific page field
-    $('#link').val(specificPage)
+    if (specificPage && !(GOVUK.feedback.getPathFor(specificPage).startsWith('/contact'))) {
+      $('#link').val(specificPage)
+    }
 
     // Choose "A specific page" option if the form was linked to directly
     if (specificPage && !(GOVUK.feedback.getPathFor(specificPage) === '/contact')) {


### PR DESCRIPTION
Bug fix, this was always intended behaviour it seems but previously
the form would be pre-filled with the URL of the contact page rather
than what the user entered after an invalid submission.

Trello: https://trello.com/c/8lCDbsQv/2323-3-contact-form-doesnt-retain-url-entered-by-user-after-an-error