### PR TITLE
Switch to new Design System link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
+$govuk-new-link-styles: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";


### PR DESCRIPTION
The new DS link styles are being rolled out across GOVUK.

We've already applied the new styles to the individual components in the components gem, so the next step is to switch this flag on in the frontend apps themselves.
This is achieved by setting `$govuk-new-link-styles: true;` in `application.scss`.

Testing this should hopefully be straightforward as this application only renders a [handful of pages](https://github.com/alphagov/feedback#live-examples).