### PR TITLE
Swap to `gem_layout`

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,8 @@
-$govuk-compatibility-govuktemplate: true;
+$govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/component_support";
 @import "govuk_publishing_components/components/breadcrumbs";
 @import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/character-count";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,8 @@ class ApplicationController < ActionController::Base
     )
   end
 
+  slimmer_template :gem_layout_no_feedback_form
+
 protected
 
   def robot_script_submission_detected

--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -117,11 +117,12 @@
           email_error = @errors[:email].first
         end
       %>
-      
+
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Your email address"
         },
+        hint: "We'll only use this to reply to your message.",
         name: "contact[email]",
         type: "email",
         id: "email",
@@ -129,11 +130,7 @@
         value: @old ? @old[:email] : '',
         error_message: email_error
       } %>
-
-      <%= render "govuk_publishing_components/components/hint", {
-        text: "We'll only use this to reply to your message."
-      } %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/button", text: "Send message" %>
+    <%= render "govuk_publishing_components/components/button", text: "Send message", margin_bottom: true %>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,9 +23,6 @@
           </div>
         </div>
       </main>
-      <% unless @hide_feedback_component %>
-        <%= render 'govuk_publishing_components/components/feedback' %>
-      <% end %>
     </div>
   </body>
 </html>

--- a/app/views/shared/_spam_honeypot.html.erb
+++ b/app/views/shared/_spam_honeypot.html.erb
@@ -1,5 +1,5 @@
 <%# Honeypot field intended to reduce spam %>
-<div class="visually-hidden" aria-hidden="true">
+<div class="govuk-visually-hidden" aria-hidden="true">
   <label for="giraffe"></label>
   <input type="text" tabindex="-1" autocomplete="off" id="giraffe" name="<%= "#{form_name}" %>[giraffe]"/>
 </div>


### PR DESCRIPTION
### What

Update `feedback` to use the Design System-based page layout

### Why

Major benefits include performance improvements, accessibility improvements, and consistency with other applications.

### Visual changes
Example page
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![www gov uk_contact_govuk (1)](https://user-images.githubusercontent.com/788096/128015416-0691b2a6-1bfa-4417-b83a-1c5f4216f22d.png)


</td><td valign="top">

![localhost_3028_contact_govuk](https://user-images.githubusercontent.com/788096/128013743-b924ee96-e23e-4ca5-899e-55f7af39a00e.png)


</td></tr>
</table>


### Notes
Requires the following to be merged and deployed:
- [x] https://github.com/alphagov/static/pull/2554
