### PR TITLE
Decouple NotifyService naming from EmailSurveySignup

### DIFF
--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -1,7 +1,7 @@
 module Contact
   module Govuk
     class EmailSurveySignupController < ContactController
-      rescue_from SurveyNotifyService::Error, with: :respond_to_notify_error
+      rescue_from NotifyService::Error, with: :respond_to_notify_error
 
       def create
         data = contact_params.merge(browser_attributes)

--- a/app/lib/feedback.rb
+++ b/app/lib/feedback.rb
@@ -2,5 +2,5 @@ module Feedback
   mattr_accessor :support
   mattr_accessor :support_api
   mattr_accessor :assisted_digital_spreadsheet
-  mattr_accessor :survey_notify_service
+  mattr_accessor :notify_service
 end

--- a/app/lib/notify_service.rb
+++ b/app/lib/notify_service.rb
@@ -1,7 +1,7 @@
 require "notifications/client"
 require "notifications/client/response_notification"
 
-class SurveyNotifyService
+class NotifyService
   class Error < StandardError
     attr_reader :cause
 
@@ -15,8 +15,8 @@ class SurveyNotifyService
     @api_key = api_key
   end
 
-  def send_email(survey_signup)
-    client.send_email(survey_signup.to_notify_params)
+  def send_email(email_parameters)
+    client.send_email(email_parameters.to_notify_params)
   rescue Notifications::Client::RequestError => e
     raise Error.new("Communication with notify service failed", e)
   end

--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -27,7 +27,7 @@ class EmailSurveySignup
   end
 
   def save
-    Rails.application.config.survey_notify_service.send_email(self) if valid?
+    Rails.application.config.notify_service.send_email(self) if valid?
   end
 
   def survey_source=(new_survey_source)
@@ -80,7 +80,7 @@ private
   end
 
   def template_id
-    @template_id ||= ENV.fetch("GOVUK_NOTIFY_TEMPLATE_ID", "fake-test-template-id")
+    @template_id ||= ENV.fetch("GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID", "fake-test-template-id")
   end
 
   def survey_source_is_relative

--- a/config/initializers/notify_service.rb
+++ b/config/initializers/notify_service.rb
@@ -1,4 +1,4 @@
-require "survey_notify_service"
+require "notify_service"
 
 api_key = if Rails.env.test?
             # This is not a valid key, but it has the right form so the client
@@ -8,4 +8,4 @@ api_key = if Rails.env.test?
             ENV["GOVUK_NOTIFY_API_KEY"]
           end
 
-Rails.application.config.survey_notify_service = SurveyNotifyService.new(api_key)
+Rails.application.config.notify_service = NotifyService.new(api_key)

--- a/docs/email_survey_signups.md
+++ b/docs/email_survey_signups.md
@@ -21,7 +21,7 @@ service running per environment. The API key is provided with the env var:
     GOVUK_NOTIFY_API_KEY
 
 The email template is provided with the env var:
-    GOVUK_NOTIFY_TEMPLATE_ID
+    GOVUK_NOTIFY_SURVEY_SIGNUP_TEMPLATE_ID
 
 Deployed environments have this filled in via puppet and our standard mechanism
 for handling keys.  On the GOV.UK dev vm you'll want to join the service on

--- a/spec/lib/notify_service_spec.rb
+++ b/spec/lib/notify_service_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
-require "survey_notify_service"
+require "notify_service"
 
-RSpec.describe SurveyNotifyService do
+RSpec.describe NotifyService do
   include EmailSurveyHelpers
 
   let(:education_email_survey) { create_education_email_survey }

--- a/spec/models/email_survey_signup_spec.rb
+++ b/spec/models/email_survey_signup_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe EmailSurveySignup, type: :model do
 
     context "#save" do
       it "sends an email to the email address using GOV.UK notify" do
-        expect(Rails.application.config.survey_notify_service).to receive(:send_email).with(subject)
+        expect(Rails.application.config.notify_service).to receive(:send_email).with(subject)
         subject.save
       end
 
       it "should raise an exception if the GOV.UK notify call doesn't work" do
-        allow(Rails.application.config.survey_notify_service).to receive(:send_email).and_raise(SurveyNotifyService::Error.new("uh-oh!"))
-        expect { subject.save }.to raise_error(SurveyNotifyService::Error, "uh-oh!")
+        allow(Rails.application.config.notify_service).to receive(:send_email).and_raise(NotifyService::Error.new("uh-oh!"))
+        expect { subject.save }.to raise_error(NotifyService::Error, "uh-oh!")
       end
     end
   end
@@ -40,7 +40,7 @@ RSpec.describe EmailSurveySignup, type: :model do
 
     context "#save" do
       it "does not send an email using GOV.UK notify" do
-        expect(Rails.application.config.survey_notify_service).not_to receive(:send_email)
+        expect(Rails.application.config.notify_service).not_to receive(:send_email)
         subject.save
       end
     end


### PR DESCRIPTION
Feedback's Notify configuration has only been used by EmailSurveySignup.

Whilst the implementation is generic, the naming was directly coupled
to the EmailSurvey.

This PR makes the naming more generic so other Feedback models may make
use of Notify.

Dependent on  https://github.com/alphagov/govuk-puppet/pull/11283 deployed and puppet running