### PR TITLE
Change radio heading to legend

### DIFF
--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -44,8 +44,10 @@
     <% end %>
 
     <%= render "govuk_publishing_components/components/radio", {
-      heading: "What's it to do with?",
       name: "contact[location]",
+      heading: "What's it to do with?",
+      heading_size: "m",
+      heading_level: 0,
       id_prefix: "location",
       items: [
         {


### PR DESCRIPTION
## What 

Change "What's it to do with?" from a `h2` to a `legend` yet maintaining the same Design

## Why

[GOV.UK Contact page](https://www.gov.uk/contact/govuk) was flagged as having a confusing heading structure ([WCAG 2.4.6](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html))

"Contact GOV.UK" is `h1 `
"What's it to do with?" is a `h2` however
"What are the details?, Do you want a reply?" are `legends`

On first look, "What are the details?, Do you want a reply?" looked as though they needed to be updated to `heading`s.  However from investigation this doesn't appear to be the ideal at the moment.

The ideal solution would be to restructure this page to ask "[one question per page](https://design-system.service.gov.uk/patterns/question-pages/#start-by-asking-one-question-per-page)" as per the Design System's Guidance, however this is out of scope.  

Headings nested inside legends has been [added in HTML 5.2](https://github.com/w3c/html/issues/724), that the [Design System team have been part of](https://github.com/whatwg/html/pull/5090). Another approach would have been to add headings to the other `legend`s.  However from an accessibility POV - from this update - there seem to be some additional considerations to take into account [with JAWS not recognising headings while nested inside a `legend`](https://github.com/alphagov/govuk-frontend/issues/1605)

[On balance](https://www.accessibility-developer-guide.com/examples/forms/grouping-with-headings/), we decided to remove the `h2` on the page as it shouldn't be a parent to the rest of the page. This is then more inline with Design System guidance, resolves the confusing structure and doesn't impact JAWs users for the moment.

## Visuals 

(No change, screenshot for context)

![GOVUK Contact us Page](https://user-images.githubusercontent.com/71266765/135726421-3c6bd856-4b09-4932-b652-4a0de89ae7ea.png)