### PR TITLE
Make EmailSurveySignup rely_to_id variable more generic

### DIFF
--- a/app/models/email_survey_signup.rb
+++ b/app/models/email_survey_signup.rb
@@ -76,7 +76,7 @@ class EmailSurveySignup
 private
 
   def reply_to_id
-    @reply_to_id ||= ENV.fetch("GOVUK_NOTIFY_REPLY_TO_ID", "fake-test-reply-to-id")
+    @reply_to_id ||= ENV.fetch("GOVUK_NOTIFY_SURVEY_SIGNUP_REPLY_TO_ID", "fake-test-reply-to-id")
   end
 
   def template_id


### PR DESCRIPTION
Feedback's Notify configuration has only been used by EmailSurveySignup.

This PR renames the email address reply_tyo variable to be more specific,
use of Notify.

Dependent on alphagov/govuk-puppet#11294 deployed and puppet running