### PR TITLE
Set cache max_age to MAX_AGE env var or 5 minutes

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -4,7 +4,7 @@ class ContactController < ApplicationController
   include Slimmer::Headers
   include ApplicationHelper
 
-  before_action :set_cache_control, only: %i[new index]
+  before_action :set_expiry, only: %i[new index]
 
   def index
     @popular_links = filtered_links(CONTACT_LINKS.popular)
@@ -109,8 +109,8 @@ private
     params[type] || {}
   end
 
-  def set_cache_control
-    expires_in 10.minutes, public: true unless Rails.env.development?
+  def set_expiry
+    expires_in Rails.application.config.max_age, public: true unless Rails.env.development?
   end
 
   def browser_attributes

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,7 @@ module Feedback
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    config.max_age = ENV["MAX_AGE"] || 300
   end
 end

--- a/spec/support/govuk_contact.rb
+++ b/spec/support/govuk_contact.rb
@@ -5,9 +5,9 @@ RSpec.shared_examples_for "a GOV.UK contact" do
       expect(response).to be_successful
     end
 
-    it "should set cache control headers for 10 mins" do
+    it "should set cache control headers for 5 mins" do
       get :new
-      expect(response.headers["Cache-Control"]).to eq("max-age=600, public")
+      expect(response.headers["Cache-Control"]).to eq("max-age=300, public")
       expect(response).to be_successful
     end
 


### PR DESCRIPTION
## What

Set the cache max age to the MAX_AGE env var if that is set otherwise default to 5 minutes rather than 10.

## Reference 

https://trello.com/c/OaUhq6uI/722-replatform-emergency-banner