### PR TITLE
Validate hidden spam field in feedback component submissions

### DIFF
--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -3,7 +3,7 @@ require "gds_api/support"
 class ReportAProblemTicket < Ticket
   SOURCE_WHITELIST = %w[mainstream inside_government page_not_found].freeze
 
-  attr_accessor :what_wrong, :what_doing, :referrer
+  attr_accessor :what_wrong, :what_doing, :giraffe, :referrer
   attr_writer :page_owner, :javascript_enabled, :source
 
   validates :what_wrong, presence: true, if: proc { |ticket| ticket.what_doing.blank? }

--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -8,4 +8,5 @@ Rails.application.config.problem_report_spam_matchers = [
   # get rid of very low-quality feedback where "what_wrong" and "what_doing" are
   # either single words or missing completely
   ->(ticket) { ticket.what_wrong.exclude?(" ") && ticket.what_doing.exclude?(" ") },
+  ->(ticket) { ticket.giraffe.present? },
 ].freeze

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe ReportAProblemTicket, type: :model do
     expect(ticket(what_doing: "").errors[:what_doing].size).to eq(1)
   end
 
+  it "should validate the absence of 'giraffe'" do
+    expect(ticket(giraffe: "").errors[:giraffe].size).to eq(0)
+  end
+
+  it "should invalidate the presence of 'giraffe' (suspected spam)" do
+    expect(ticket(giraffe: "Lorem ipsum dolor sit amet, consectetur adipiscing elit").errors[:giraffe].size).to eq(1)
+  end
+
   it "should filter 'javascript_enabled'" do
     expect(ticket(javascript_enabled: "true").javascript_enabled).to be_truthy
 


### PR DESCRIPTION
## What
https://trello.com/c/H8jJvUxV/1021-feedback-component-server-side-fix-for-spam-problem

Validate that the hidden (`giraffe`) - "honeypot" input - is absent from submissions. The helper _"checks if the value is not either nil or a blank string, that is, a string that is either empty or consists of whitespace"_.
https://guides.rubyonrails.org/active_record_validations.html#absence

## Why

It seems likely that by resolving a number of accessibility issues (https://trello.com/c/MOshcFm1/771-update-feedback-component-to-hide-and-show-content-in-a-more-robust-way) we have inadvertently made it easier for spam bots to access the feedback component forms and client side changes have not resolved the problem. 

## Anything else
Should be deployed after: https://github.com/alphagov/govuk_publishing_components/pull/2586

`def spam` would seem to be a better place to check for spam:

https://github.com/alphagov/feedback/blob/1e7a40b92b57d389f799c6391662d59bac70bd31/app/models/report_a_problem_ticket.rb#L30-L32

Yet I can't seem to get any changes to work here. I've tried various examples such as:

```
  ->(ticket) { ticket.what_wrong.exclude?(" ") && ticket.what_doing.exclude?(" ") },
  ->(ticket) { ticket.feedback_maybe.exclude?(nil) },
```