### PR TITLE
Mark duplicate values in "What were you doing?" and "What went wrong?" fields as spam in feedback component

### DIFF
--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -9,4 +9,6 @@ Rails.application.config.problem_report_spam_matchers = [
   # either single words or missing completely
   ->(ticket) { ticket.what_wrong.exclude?(" ") && ticket.what_doing.exclude?(" ") },
   ->(ticket) { ticket.giraffe.present? },
+  # mark duplicate values in "what_wrong" and "what_doing" fields as spam
+  ->(ticket) { ticket.what_wrong == ticket.what_doing },
 ].freeze

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -82,6 +82,10 @@ RSpec.describe ReportAProblemTicket, type: :model do
       expect(ticket(what_wrong: "WCRTESTINP scanning")).to be_spam
     end
 
+    it "should mark duplicate values in 'what_doing' and 'what_wrong' fields as spam" do
+      expect(ticket(what_doing: "Lorem ipsum dolor sit amet", what_wrong: "Lorem ipsum dolor sit amet")).to be_spam
+    end
+
     it "should allow genuine submissions" do
       expect(ticket(what_doing: "browsing", what_wrong: "it broke")).to_not be_spam
     end


### PR DESCRIPTION
## What
https://trello.com/c/XfBsdUVD/1042-feedback-component-server-side-fix-for-spam-problem-check-for-identical-spam-in-what-were-you-doing-and-what-went-wrong-fields

Mark duplicate values in "What were you doing?" and "What went wrong?" fields as spam in feedback component.

## Why

I have spotted a pattern in what's still appearing in that the spammers seem to stick the same piece of junk text into both the "what were you doing" and "what went wrong" fields. Jon, I believe if you head back to the feedback app and validate for field 1 not being equal to field 2 we should remove the bulk of the bad stuff.

## Anything else

This may result in a small number of valid comments being lost, but they will be comments where the user is not using the form correctly so I think that's acceptable.

See history of this issue:
- https://github.com/alphagov/feedback/pull/1354