### PR TITLE
Add Javascript tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "valid_email"
 group :development, :test do
   gem "govuk-content-schema-test-helpers"
   gem "govuk_test"
+  gem "jasmine"
+  gem "jasmine_selenium_runner"
   gem "pry-byebug"
   gem "rails-controller-testing"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,16 @@ GEM
     i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     invalid_utf8_rejector (0.0.4)
+    jasmine (3.99.0)
+      jasmine-core (= 3.99.0)
+      phantomjs
+      rack (>= 2.1.4)
+      rake
+      webrick
+    jasmine-core (3.99.0)
+    jasmine_selenium_runner (3.0.0)
+      jasmine (~> 3.0)
+      selenium-webdriver (~> 3.8)
     json (2.6.1)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -208,6 +218,7 @@ GEM
     parallel (1.21.0)
     parser (3.1.0.0)
       ast (~> 2.4.1)
+    phantomjs (2.1.1.0)
     plek (4.0.0)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -389,6 +400,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.7.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -407,6 +419,8 @@ DEPENDENCIES
   govuk_publishing_components
   govuk_test
   invalid_utf8_rejector
+  jasmine
+  jasmine_selenium_runner
   notifications-ruby-client
   plek
   pry-byebug

--- a/Rakefile
+++ b/Rakefile
@@ -6,4 +6,4 @@ require File.expand_path("config/application", __dir__)
 Rails.application.load_tasks
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[lint spec]
+task default: %i[lint spec jasmine:ci]

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -59,8 +59,12 @@
     form.appendChild(referrerInput)
   }
 
+  GOVUK.feedback.getLocationPathname = function () {
+    return window.location.pathname
+  }
+
   GOVUK.feedback.init = function () {
-    if (window.location.pathname === '/contact') {
+    if (this.getLocationPathname() === '/contact') {
       this.saveReferrerToCookie()
     }
 

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -17,7 +17,7 @@ port        ENV.fetch("PORT", 3000)
 environment ENV.fetch("RAILS_ENV") { "development" }
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+# pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "license": "MIT",
   "scripts": {
     "lint": "yarn run lint:js && yarn run lint:scss",
-    "lint:js": "standardx 'app/assets/javascripts/**/*.js'",
+    "lint:js": "standardx 'app/assets/javascripts/**/*.js' 'spec/javascripts/**/*.js'",
     "lint:scss": "stylelint app/assets/stylesheets/"
   },
   "standardx": {
     "env": {
       "browser": true,
+      "jasmine": true,
       "jquery": true
     },
     "globals": [

--- a/spec/javascripts/spec/feedback.spec.js
+++ b/spec/javascripts/spec/feedback.spec.js
@@ -1,0 +1,99 @@
+describe('Feedback', function () {
+  'use strict'
+
+  it('can extract a path from a URL', function () {
+    expect(GOVUK.feedback.getPathFor('http://example.com/this/is/the/path')).toBe('/this/is/the/path')
+  })
+
+  describe('when on the contact page', function () {
+    var locationPathnameSpy
+
+    beforeEach(function () {
+      locationPathnameSpy = spyOn(GOVUK.feedback, 'getLocationPathname').and.returnValue('/contact')
+      GOVUK.feedback.init()
+    })
+
+    afterEach(function () {
+      locationPathnameSpy.and.callThrough()
+    })
+
+    it('stores the referrer in a cookie', function () {
+      expect(GOVUK.getCookie('govuk_contact_referrer')).toBe(document.referrer)
+    })
+  })
+
+  describe('when there is a feedback form on the page', function () {
+    var contactForm, linkInput, specificLocationInput, javascriptEnabledInput, referrerInput
+
+    beforeAll(function () {
+      contactForm = document.createElement('form')
+      contactForm.setAttribute('class', 'contact-form')
+      linkInput = document.createElement('input')
+      linkInput.setAttribute('name', 'contact[link]')
+      contactForm.appendChild(linkInput)
+      specificLocationInput = document.createElement('input')
+      specificLocationInput.setAttribute('name', 'contact[location]')
+      specificLocationInput.setAttribute('value', 'specific')
+      specificLocationInput.setAttribute('type', 'checkbox')
+      contactForm.appendChild(specificLocationInput)
+      document.body.appendChild(contactForm)
+    })
+
+    beforeEach(function () {
+      linkInput.value = ''
+      specificLocationInput.checked = false
+      GOVUK.feedback.init()
+      javascriptEnabledInput = contactForm.querySelector('[name="contact[javascript_enabled]"]')
+      referrerInput = contactForm.querySelector('[name="contact[referrer]"]')
+    })
+
+    afterEach(function () {
+      javascriptEnabledInput.remove()
+      referrerInput.remove()
+    })
+
+    it('appends a hidden field indicating javascript was enabled', function () {
+      expect(javascriptEnabledInput.value).toBe('true')
+    })
+
+    it('appends a hidden field recording the referrer', function () {
+      expect(referrerInput.value).toBe(document.referrer)
+    })
+
+    describe('when no link URL is given', function () {
+      it('uses the referrer URL', function () {
+        expect(linkInput.value).toBe(document.referrer)
+      })
+    })
+
+    describe('when a link URL is given', function () {
+      beforeEach(function () {
+        linkInput.value = 'http://example.com'
+        GOVUK.feedback.init()
+      })
+
+      it('selects the "A specific page" option', function () {
+        expect(specificLocationInput.checked).toBe(true)
+      })
+    })
+
+    describe('when there is an email address in the specific page URL', function () {
+      var cookieSpy
+
+      beforeEach(function () {
+        linkInput.value = ''
+        var referrerWithEmail = document.referrer + '?email=test@example.com'
+        cookieSpy = spyOn(GOVUK, 'cookie').and.returnValue(referrerWithEmail)
+        GOVUK.feedback.init()
+      })
+
+      afterEach(function () {
+        cookieSpy.and.callThrough()
+      })
+
+      it('masks all email addresses in the URL', function () {
+        expect(linkInput.value).toBe(document.referrer + '?email=[email]')
+      })
+    })
+  })
+})

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -1,0 +1,145 @@
+# src_files
+#
+# Return an array of filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# src_files:
+#   - lib/source1.js
+#   - lib/source2.js
+#   - 'dist/**/*.js'
+#
+src_files:
+  - assets/application.js
+
+# stylesheets
+#
+# Return an array of stylesheet filepaths relative to src_dir to include before jasmine specs.
+# Default: []
+#
+# EXAMPLE:
+#
+# stylesheets:
+#   - css/style.css
+#   - 'stylesheets/*.css'
+#
+stylesheets:
+  - assets/application.css
+
+# helpers
+#
+# Return an array of filepaths relative to spec_dir to include before jasmine specs.
+# Default: ["helpers/**/*.js"]
+#
+# EXAMPLE:
+#
+# helpers:
+#   - 'helpers/**/*.js'
+#
+helpers:
+  - 'helpers/**/*.js'
+
+# spec_files
+#
+# Return an array of filepaths relative to spec_dir to include.
+# Default: ["**/*[sS]pec.js"]
+#
+# EXAMPLE:
+#
+# spec_files:
+#   - '**/*[sS]pec.js'
+#
+spec_files:
+  - '**/*[sS]pec.js'
+
+# src_dir
+#
+# Source directory path. Your src_files must be returned relative to this path. Will use root if left blank.
+# Default: project root
+#
+# EXAMPLE:
+#
+# src_dir: public
+#
+src_dir:
+
+# spec_dir
+#
+# Spec directory path. Your spec_files must be returned relative to this path.
+# Default: spec/javascripts
+#
+# EXAMPLE:
+#
+# spec_dir: spec/javascripts
+#
+spec_dir:
+
+# spec_helper
+#
+# Ruby file that Jasmine server will require before starting.
+# Returned relative to your root path
+# Default spec/javascripts/support/jasmine_helper.rb
+#
+# EXAMPLE:
+#
+# spec_helper: spec/javascripts/support/jasmine_helper.rb
+#
+spec_helper: spec/javascripts/support/jasmine_helper.rb
+
+# boot_dir
+#
+# Boot directory path. Your boot_files must be returned relative to this path.
+# Default: Built in boot file
+#
+# EXAMPLE:
+#
+# boot_dir: spec/javascripts/support/boot
+#
+boot_dir:
+
+# boot_files
+#
+# Return an array of filepaths relative to boot_dir to include in order to boot Jasmine
+# Default: Built in boot file
+#
+# EXAMPLE
+#
+# boot_files:
+#   - '**/*.js'
+#
+boot_files:
+
+# rack_options
+#
+# Extra options to be passed to the rack server
+# by default, Port and AccessLog are passed.
+#
+# This is an advanced options, and left empty by default
+#
+# EXAMPLE
+#
+# rack_options:
+#   server: 'thin'
+
+# phantom_cli_options
+#
+# Extra options to be passed to the phantomjs cli,
+# e.g. to enable localStorage in PhantomJs 2.5
+#
+# EXAMPLE
+#
+# phantom_cli_options:
+#   local-storage-quota: 5000
+
+# random
+#
+# Run specs in semi-random order.
+# Default: true
+#
+# EXAMPLE:
+#
+# random: false
+#
+random:
+

--- a/spec/javascripts/support/jasmine_helper.rb
+++ b/spec/javascripts/support/jasmine_helper.rb
@@ -1,0 +1,7 @@
+require "jasmine_selenium_runner/configure_jasmine"
+
+class HeadlessChromeJasmineConfigurer < JasmineSeleniumRunner::ConfigureJasmine
+  def selenium_options
+    { options: GovukTest.headless_chrome_selenium_options }
+  end
+end

--- a/spec/javascripts/support/jasmine_selenium_runner.yml
+++ b/spec/javascripts/support/jasmine_selenium_runner.yml
@@ -1,0 +1,2 @@
+browser: chrome
+configuration_class: HeadlessChromeJasmineConfigurer


### PR DESCRIPTION
As part of enabling continuous deployment, the feedback app must be brought up to a minimum level of safety checks - this includes at least one Javascript test as JS is in use.

Setting up Jasmine tests with the `rails generate jasmine:install` command created most of the files and directory structure, but `spec/javascripts/support/jasmine_helper.rb` is taken from [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components).

Gemfile and Rakefile modifications were copied from [email-alert-frontend](https://github.com/alphagov/govuk_publishing_components).

There may be too many tests added here, as I think there is some overlap with the Ruby tests.

The `jasmine` gem has been discontinued, but I didn't try to migrate to the `jasmine-browser-runner` npm package, as that seems like a much larger task and outside of the scope of this change.