### PR TITLE
Add CD PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,1 @@
-:warning: This application is Continuously Deployed: :warning:
-
-- Merged changes are automatically deployed to staging and production.
-
-- Make sure you follow [the guidance for
-  deployments](http://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)
-  **before** you merge.
-
-- Check your branch is being deployed in the [Release
-  app](https://release.publishing.service.gov.uk/applications/feedback), after
-  merging.
+⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+:warning: This application is Continuously Deployed: :warning:
+
+- Merged changes are automatically deployed to staging and production.
+
+- Make sure you follow [the guidance for
+  deployments](http://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request)
+  **before** you merge.
+
+- Check your branch is being deployed in the [Release
+  app](https://release.publishing.service.gov.uk/applications/feedback), after
+  merging.


### PR DESCRIPTION
One of the steps for enabling continuous deployment is to add a PR
template with a warning that merged changes will be automatically
deployed to staging and production.

https://trello.com/c/aFEtQrTu/1017-enable-continuous-deployment-for-feedback