### PR TITLE
Update deprecated errors block to clear messages in test suite

### DIFF
--- a/app/models/multi_ticket.rb
+++ b/app/models/multi_ticket.rb
@@ -31,8 +31,8 @@ class MultiTicket
     def errors
       errors = ActiveModel::Errors.new(self)
       @tickets.map(&:errors).each do |ticket_errors|
-        ticket_errors.each do |attribute, error|
-          errors.add(attribute, error)
+        ticket_errors.each do |error|
+          errors.add(error.attribute, error.message)
         end
       end
       errors


### PR DESCRIPTION
Deprecation messages because error blocks will soon just return one argument, an error with attributes.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
