### PR TITLE
Add request accessible format form to publish special routes task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -22,6 +22,15 @@ namespace :publishing_api do
       rendering_app: "feedback",
     )
 
+    special_route_publisher.publish(
+      content_id: "34761d23-eafa-4025-82bf-0d127e06e8be",
+      title: "Request accessible format",
+      base_path: "/contact/govuk/request-accessible-format",
+      type: "exact",
+      publishing_app: "feedback",
+      rendering_app: "feedback",
+    )
+
     redirect_publisher = RedirectPublisher.new(
       logger: logger,
       publishing_app: "feedback",


### PR DESCRIPTION
This adds the accessible format request form to the publishing api special routes publisher rake task.

Dependent on https://github.com/alphagov/feedback/pull/1363 being merged and deployed before running

[trello](https://trello.com/c/OTOmVGAq/1111-accessible-format-request-add-form-url-to-special-routes-republisher-rake-task)