### PR TITLE
Ensure Accessible Format Request fetches live content items

### DIFF
--- a/app/helpers/accessible_format_helper.rb
+++ b/app/helpers/accessible_format_helper.rb
@@ -27,7 +27,7 @@ module AccessibleFormatHelper
 private
 
   def content_item
-    @content_item ||= GdsApi.publishing_api.get_content(params[:content_id]).to_h
+    @content_item ||= GdsApi.publishing_api.get_live_content(params[:content_id]).to_h
   end
 
   def requested_attachment

--- a/spec/requests/accessible_format_request_spec.rb
+++ b/spec/requests/accessible_format_request_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe "Requests for accessible formats of documents", type: :request do
     {
       base_path: "/government/publications/example-document",
       content_id: content_id,
+      publication_state: "published",
       title: "A document with some inaccessible attachments",
       details: {
         attachments: [


### PR DESCRIPTION
This commit ensures that only live, rather than draft, content items are fetched when making accessible format requests.