### PR TITLE
Fix tracking implementation on continue button

### DIFF
--- a/app/views/contact/govuk/accessible_format_requests/contact_details.html.erb
+++ b/app/views/contact/govuk/accessible_format_requests/contact_details.html.erb
@@ -53,9 +53,9 @@
       text: t("controllers.contact.govuk.accessible_format_requests.continue"),
       data_attributes: {
         module: "gem-track-click",
-        "data-track-category": "requestAccessible",
-        "data-track-action": params["format_type"]&.capitalize + " - Cabinet Office",
-        "data-track-label": params["attachment_title"]
+        "track-category": "requestAccessible",
+        "track-action": params["format_type"]&.capitalize + " - Cabinet Office",
+        "track-label": attachment_title
       }
     } %>
   </p>


### PR DESCRIPTION
## What
https://trello.com/c/QvEohsT7/1153-fix-link-tracking-on-continue-button-for-request-accessible-format

- Fix incorrect tracking implementation of `data_attributes`.
- Fix incorrect `data-track-label` attribute

```
<button class="gem-c-button govuk-button" 
  type="submit" 
  data-module="gem-track-click" 
  data-track-category="requestAccessible"
  data-track-action="Audio - Cabinet Office" 
  data-track-label="Second State Pension age review: independent report call for evidence">Continue
</button>
```

## Why

The link tracking on the **Continue** button, on **Contact information**, is currently not generating any GA events. This is very likely due to an incorrect implementation of the tracking attributes. Double `data` attributes are rendered. Also, the attachment title is not pulled through in to `track-label` attribute.

```
<button class="gem-c-button govuk-button" 
  type="submit" 
  data-module="gem-track-click" 
  data-data-track-category="requestAccessible" 
  data-data-track-action="Audio - Cabinet Office">Continue
</button>
```

## Anything else