### PR TITLE
Add request accessible format start page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/fieldset";
 @import "govuk_publishing_components/components/hint";
 @import "govuk_publishing_components/components/input";
+@import "govuk_publishing_components/components/inset-text";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/panel";
 @import "govuk_publishing_components/components/radio";

--- a/app/controllers/contact/govuk/accessible_format_requests_controller.rb
+++ b/app/controllers/contact/govuk/accessible_format_requests_controller.rb
@@ -10,8 +10,15 @@ class Contact::Govuk::AccessibleFormatRequestsController < ContactController
 
   layout "accessible_format_requests"
 
-  def format_type
+  def start_page
     @back_path = helpers.content_path
+  end
+
+  def format_type
+    @back_path = contact_govuk_request_accessible_format_path(
+      content_id: params[:content_id],
+      attachment_id: params[:attachment_id],
+    )
 
     if params[:error] == "format-type-missing"
       flash.now[:input_errors] = [[I18n.t("controllers.contact.govuk.accessible_format_requests.format_type_error"), "format_type"]]
@@ -25,7 +32,7 @@ class Contact::Govuk::AccessibleFormatRequestsController < ContactController
   end
 
   def contact_details
-    @back_path = contact_govuk_request_accessible_format_path(
+    @back_path = contact_govuk_request_accessible_format_format_type_path(
       content_id: params[:content_id],
       attachment_id: params[:attachment_id],
       format_type: params[:format_type],
@@ -33,9 +40,9 @@ class Contact::Govuk::AccessibleFormatRequestsController < ContactController
     )
 
     if params[:format_type].blank?
-      redirect_to(contact_govuk_request_accessible_format_path(content_id: params[:content_id], attachment_id: params[:attachment_id], error: "format-type-missing"))
+      redirect_to(contact_govuk_request_accessible_format_format_type_path(content_id: params[:content_id], attachment_id: params[:attachment_id], error: "format-type-missing"))
     elsif params[:format_type] == "other" && params[:other_format].blank?
-      redirect_to(contact_govuk_request_accessible_format_path(content_id: params[:content_id], attachment_id: params[:attachment_id], format_type: "other", error: "other-format-missing"))
+      redirect_to(contact_govuk_request_accessible_format_format_type_path(content_id: params[:content_id], attachment_id: params[:attachment_id], format_type: "other", error: "other-format-missing"))
     end
   end
 

--- a/app/controllers/contact/govuk/accessible_format_requests_controller.rb
+++ b/app/controllers/contact/govuk/accessible_format_requests_controller.rb
@@ -1,7 +1,7 @@
 require "gds_api/publishing_api"
 
 class Contact::Govuk::AccessibleFormatRequestsController < ContactController
-  before_action :check_content_specified
+  before_action :check_content, except: :request_sent
 
   class AttachmentNotFoundError < StandardError; end
 
@@ -78,9 +78,17 @@ class Contact::Govuk::AccessibleFormatRequestsController < ContactController
 
 private
 
-  def check_content_specified
+  def check_content
     slimmer_template(:gem_layout_no_feedback_form)
-    render("missing_item") unless params[:content_id] && params[:attachment_id]
+    render("missing_item") unless content_specified? && content_available?
+  end
+
+  def content_specified?
+    params[:content_id] && params[:attachment_id]
+  end
+
+  def content_available?
+    helpers.document_and_attachment_available?
   end
 
   def content_item_error

--- a/app/helpers/accessible_format_helper.rb
+++ b/app/helpers/accessible_format_helper.rb
@@ -24,6 +24,10 @@ module AccessibleFormatHelper
     values
   end
 
+  def document_and_attachment_available?
+    content_item && requested_attachment
+  end
+
 private
 
   def content_item

--- a/app/views/contact/govuk/accessible_format_requests/contact_details.html.erb
+++ b/app/views/contact/govuk/accessible_format_requests/contact_details.html.erb
@@ -7,7 +7,7 @@
   %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: @back_path } %>
+<% content_for :back_link, @back_path %>
 
 <% if flash[:input_errors]&.any? %>
   <%= render "govuk_publishing_components/components/error_summary", {

--- a/app/views/contact/govuk/accessible_format_requests/format_type.html.erb
+++ b/app/views/contact/govuk/accessible_format_requests/format_type.html.erb
@@ -7,7 +7,7 @@
   %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/back_link", { href: @back_path } %>
+<% content_for :back_link, @back_path %>
 
 <% if flash[:input_errors]&.any? %>
   <%= render "govuk_publishing_components/components/error_summary", {

--- a/app/views/contact/govuk/accessible_format_requests/start_page.html.erb
+++ b/app/views/contact/govuk/accessible_format_requests/start_page.html.erb
@@ -1,0 +1,47 @@
+<% content_for :title do %>
+  <%= t("controllers.contact.govuk.accessible_format_requests.start_page.request_heading") %>
+<% end %>
+
+<% content_for :back_link, @back_path %>
+
+<%= render "govuk_publishing_components/components/heading", {
+  text: t("controllers.contact.govuk.accessible_format_requests.start_page.request_heading"),
+  heading_level: 1,
+  font_size: "l",
+} %>
+
+<p class="govuk-body">
+  <%= t("controllers.contact.govuk.accessible_format_requests.start_page.condition_impairment_body") %>
+</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: t("controllers.contact.govuk.accessible_format_requests.start_page.condition_impairment_list_items")
+} %>
+
+<p class="govuk-body">
+  <%= t("controllers.contact.govuk.accessible_format_requests.start_page.requirements_body") %>
+</p>
+
+<%= render "govuk_publishing_components/components/list", {
+  visible_counters: true,
+  items: t("controllers.contact.govuk.accessible_format_requests.start_page.requirements_list_items")
+} %>
+
+<p class="govuk-body">
+  <%= t("controllers.contact.govuk.accessible_format_requests.start_page.department_email_confirmation_body") %>
+</p>
+
+<%= render "govuk_publishing_components/components/inset_text", {
+  text: sanitize(t("controllers.contact.govuk.accessible_format_requests.start_page.help_text"))
+} %>
+
+<%= form_with url: contact_govuk_request_accessible_format_format_type_path, method: :get, authenticity_token: false, html: { class: "contact-form" } do |f| %>
+  <%= hidden_field_tag :content_id, params["content_id"]%>
+  <%= hidden_field_tag :attachment_id, params["attachment_id"]%>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: t("controllers.contact.govuk.accessible_format_requests.start_page.start_now"),
+    start: true
+  } %>
+<% end %>

--- a/app/views/layouts/accessible_format_requests.html.erb
+++ b/app/views/layouts/accessible_format_requests.html.erb
@@ -10,6 +10,9 @@
   </head>
   <body>
     <div id="wrapper" class="govuk-width-container">
+    <% if content_for?(:back_link) %>
+      <%= render 'govuk_publishing_components/components/back_link', { href: yield(:back_link) } %>
+    <% end %>
       <main class="govuk-main-wrapper" id="content" role="main">
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,22 @@ en:
           missing_content_caption: Request accessible documents
           content_item_error_body: <p class="govuk-body">We are unable to fulfil your request.</p><p class="govuk-body">Try again later.</p><p class="govuk-body govuk-!-margin-bottom-0">
           content_item_error_caption: Sorry, there is a problem with the service
+          start_page:
+            request_heading: Request an accessible format
+            condition_impairment_body: |-
+              You can request an accessible version of COVID-19 Winter Plan (Welsh) if you have a condition or impairment. You might need an accessible version if you have:
+            condition_impairment_list_items:
+              - dyslexia, autism or cognitive difficulties
+              - sensory disabilities, like a visual or hearing impairment
+              - physical disabilities, like reduced dexterity or limited mobility
+            requirements_body: |-
+              You’ll need to:
+            requirements_list_items:
+              - tell us which format you need
+              - provide a contact email address
+            department_email_confirmation_body: The department will then email you about your request.
+            help_text: If you need any other help or want to contact a service or department through another route, <a href="https://www.gov.uk/contact" class="govuk-link">visit the GOV.UK contact page</a>.
+            start_now: Start now
   models:
     accessible_format_options:
       - text: Audio

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,8 @@ Rails.application.routes.draw do
       post "email-survey-signup.js", to: "email_survey_signup#create", defaults: { format: :js }
       post "content_improvement", to: "content_improvement#create", defaults: { format: :js }
       resources "page_improvements", only: [:create], format: false
-      get "request-accessible-format", to: "accessible_format_requests#format_type", format: false
+      get "request-accessible-format", to: "accessible_format_requests#start_page", format: false
+      get "request-accessible-format/format-type", to: "accessible_format_requests#format_type", format: false
       post "request-accessible-format/contact-details", to: "accessible_format_requests#contact_details", format: false
       post "request-accessible-format/send-request", to: "accessible_format_requests#send_request", format: false
       get "request-accessible-format/request-sent", to: "accessible_format_requests#request_sent", format: false


### PR DESCRIPTION
This change adds a new Start Page to provide users with better
context and guidance on how to use the request accessible format
form.

It adds text to match the design and content provided.

Imported required styles for the inset-text component.

Moved the back-link component to the accessible formats requests layout,
this will render the back link underneath the header and appears consistent
with other rendering apps.

Co-Authored-By: Edward Kerry <edward.kerry@digital.cabinet-office.gov.uk>
Co-Authored-By: Martin Jones <martin.jones@digital.cabinet-office.gov.uk>

[trello](https://trello.com/c/x6QtEKU5/1145-introduce-a-start-page-to-request-accessible-format)

<img width="992" alt="desktop-new" src="https://user-images.githubusercontent.com/28779939/165064075-3e9a8641-e9b1-4a5e-9c7e-cfd5d727968f.png">