### PR TITLE
Remove easy read option from accessible format requests

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,8 +59,6 @@ en:
         value: braille
       - text: British sign language
         value: british_sign_language
-      - text: Easy read
-        value: easy_read
       - text: Large print
         value: large_print
       - text: Another accessible format


### PR DESCRIPTION
## What

Remove the Easy Read option from accessible format requests

## Visual Changes

|*Before*|*After*|
|-|-|
|<img width="1013" alt="Screenshot 2022-05-05 at 11 37 45" src="https://user-images.githubusercontent.com/28779939/166908860-544cd283-0e42-4a9d-a2f8-2599d2719bac.png">|<img width="1077" alt="Screenshot 2022-05-05 at 11 38 27" src="https://user-images.githubusercontent.com/28779939/166908923-4062f997-c3ef-4da2-90bd-afee9942264e.png">|


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
