### PR TITLE
Make Docker image run as non-root.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,12 @@
+.dockerignore
 .git
 .gitignore
+Dockerfile
 Jenkinsfile
+Procfile
 README.md
 docs
 log
 spec
+test
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,39 +1,74 @@
-ARG base_image=ruby:2.7.6-slim-buster
+ARG ruby_version=2.7.6
+ARG base_image=ruby:$ruby_version-slim-buster
+
 FROM $base_image AS builder
 
+# TODO: remove these once they're set in the base image.
 ENV RAILS_ENV=production
-# TODO: have a separate build image which already contains the build-only deps.
+ENV RAILS_LOG_TO_STDOUT=1
+ENV NODE_ENV=production
+ENV GEM_HOME=/usr/local/bundle
+ENV BUNDLE_PATH=$GEM_HOME
+ENV BUNDLE_BIN=$GEM_HOME/bin
+ENV PATH=$BUNDLE_BIN/bin:$PATH
+ENV BUNDLE_WITHOUT="development test"
+
+# TODO: set these in the builder image.
+ENV BUNDLE_IGNORE_MESSAGES=1
+ENV BUNDLE_SILENCE_ROOT_WARNING=1
+ENV BUNDLE_JOBS=12
+ENV MAKEFLAGS=-j12
+
+ENV GOVUK_APP_DOMAIN=unused
+ENV GOVUK_WEBSITE_ROOT=unused
+
+# TODO: have an up-to-date builder image and stop running apt-get upgrade.
+# TODO: have a separate builder image which already contains the build-only deps.
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \ 
+    apt-get install -y --no-install-suggests --no-install-recommends \
+        build-essential nodejs && \
     apt-get clean
 
-RUN mkdir /app
-WORKDIR /app
-COPY Gemfile* .ruby-version /app/
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install -j8 --retry=2
 
+RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
+WORKDIR /app
+COPY Gemfile Gemfile.lock .ruby-version /app/
+RUN echo 'install: --no-document' >> /etc/gemrc && bundle install
 COPY . /app
-# TODO: We probably don't want assets in the image; remove this once we have a proper deployment process which uploads to (e.g.) S3.
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk \
-    GOVUK_APP_DOMAIN=www.gov.uk \
-    bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && rm -fr /app/log
 
 
 FROM $base_image
 
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=feedback
+# TODO: set these in the base image.
+ENV RAILS_ENV=production
+ENV RAILS_LOG_TO_STDOUT=1
+ENV NODE_ENV=production
+ENV GEM_HOME=/usr/local/bundle
+ENV BUNDLE_PATH=$GEM_HOME
+ENV BUNDLE_BIN=$GEM_HOME/bin
+ENV PATH=$GEM_HOME/bin:$PATH
+ENV BUNDLE_WITHOUT="development test"
 
+ENV GOVUK_APP_NAME=feedback
+ENV GOVUK_PROMETHEUS_EXPORTER=true
+
+# TODO: have an up-to-date base image and stop running apt-get here.
 RUN apt-get update -qy && \
     apt-get upgrade -y && \
-    apt-get install -y nodejs && \
-    apt-get clean
+    apt-get clean && \
+    rm -fr /var/lib/apt/lists
 
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
-
+RUN mkdir -p /app && ln -fs /tmp /app/tmp && ln -fs /tmp /home/app
+RUN echo 'IRB.conf[:HISTORY_FILE] = "/tmp/irb_history"' > irb.rc
 WORKDIR /app
 
+COPY --from=builder /usr/bin/node* /usr/bin/
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+COPY --from=builder /app ./
+
+RUN groupadd -g 1001 app && \
+    useradd -u 1001 -g app app
+USER 1001
 CMD bundle exec puma


### PR DESCRIPTION
- Add some files to `.dockerignore`.
- Don't run as root by default.
- Set `RAILS_LOG_TO_STDOUT` because we always want that when running in a container.
- Symlink `/app/tmp` and `/home/app` to `/tmp` so that gems don't try to write to the (read-only) image filesystem. (Ruby/Rails doesn't seem to have a consistent convention for telling gems where to write temp files.)
- Run `rails assets:precompile` in the build stage.
- Avoid installing "suggested" and "recommended" dependencies of Debian packages.
- Avoid installing gem documentation.
- Avoid including the APT cache in the output image.
- Increase build parallelism (saves a couple of minutes on a 2019 MBP).

This is essentially the same changes as alphagov/signon/pull/1861, alphagov/signon/pull/1855 and alphagov/signon/pull/1856 but without switching to the Bitnami image just yet (as there's some issue with header files preventing some of the native gems from being built).

Tested: `docker run -it --rm -e GOVUK_APP_DOMAIN=x -e GOVUK_WEBSITE_ROOT=x feedback`

Rollout: this app is push-on-green, so watch out.