### PR TITLE
Change final "Continue" button text to "Send request"

### DIFF
--- a/app/views/contact/govuk/accessible_format_requests/contact_details.html.erb
+++ b/app/views/contact/govuk/accessible_format_requests/contact_details.html.erb
@@ -50,7 +50,7 @@
 
   <p class="govuk-body govuk-!-margin-bottom-0">
     <%= render "govuk_publishing_components/components/button", {
-      text: t("controllers.contact.govuk.accessible_format_requests.continue"),
+      text: t("controllers.contact.govuk.accessible_format_requests.confirm"),
       data_attributes: {
         module: "gem-track-click",
         "track-category": "requestAccessible",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,7 @@ en:
           service_unavailable: <h2>Sorry, we’re unable to receive your message right now.<h2> <p>If the problem persists, we have other ways for you to provide feedback on the contact page.</p>
         accessible_format_requests:
           caption: Request accessible format
+          confirm: Send request
           continue: Continue
           error_summary: There is a problem
           format_type_heading: Which accessible format would you like for %{attachment_title}

--- a/spec/requests/accessible_format_request_spec.rb
+++ b/spec/requests/accessible_format_request_spec.rb
@@ -180,7 +180,7 @@ RSpec.describe "Requests for accessible formats of documents", type: :request do
 
     context "with a missing email address" do
       it "shows the missing email address error" do
-        click_on "Continue"
+        click_on "Send request"
 
         expect(page).to have_content("Enter an email address")
       end
@@ -189,7 +189,7 @@ RSpec.describe "Requests for accessible formats of documents", type: :request do
     context "with an invalid email address" do
       it "shows the missing email address error" do
         fill_in :email_address, with: "ff"
-        click_on "Continue"
+        click_on "Send request"
 
         expect(page).to have_content("Enter an email address in the correct format, like name@example.com")
       end
@@ -218,12 +218,12 @@ RSpec.describe "Requests for accessible formats of documents", type: :request do
           ).and_return(stub_format_request)
 
         fill_in :email_address, with: "a@example.com"
-        click_on "Continue"
+        click_on "Send request"
       end
 
       it "redirects to the sent request confirmation view" do
         fill_in :email_address, with: "a@example.com"
-        click_on "Continue"
+        click_on "Send request"
 
         i_should_be_on contact_govuk_request_accessible_format_request_sent_path(base_params)
       end
@@ -244,7 +244,7 @@ RSpec.describe "Requests for accessible formats of documents", type: :request do
           fill_in "What accessible format do you need?", with: "a bespoke format"
           click_on "Continue"
           fill_in :email_address, with: "a@example.com"
-          click_on "Continue"
+          click_on "Send request"
 
           i_should_be_on contact_govuk_request_accessible_format_request_sent_path(base_params)
         end


### PR DESCRIPTION
## What
https://trello.com/c/LS5DV2MT/1291-request-accessible-format-change-final-continue-button-to-confirm-and-send

On the "**Contact information**" page change "_Continue_" button text to "_Send request_"

## Why

In user research, users were surprised after getting the 'request sent' page, and they didn't realise that the final Continue button would submit that request for them.

We should make it clearer that that final button is the one that finishes the submission for them.

## Visual changes

<table role="table">
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/169510103-9e21bd23-a170-4315-bf60-b1800c516ff3.png"><img src="https://user-images.githubusercontent.com/87758239/169510103-9e21bd23-a170-4315-bf60-b1800c516ff3.png" width="360" style="max-width: 100%;"></a></td>
<td valign="top"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/87758239/169512862-45b46787-1ddc-4486-8633-8481730ee213.png"><img src="https://user-images.githubusercontent.com/87758239/169512862-45b46787-1ddc-4486-8633-8481730ee213.png" width="360" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>