### PR TITLE
Add environment input for manual deployments

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,6 +8,15 @@ on:
         required: true
         type: string
         default: 'main'
+      environment:
+        description: 'Environment to deploy to'
+        required: true
+        type: choice
+        options:
+        - integration
+        - staging
+        - production
+        default: 'integration'
   push:
     branches:
       - main
@@ -24,13 +33,14 @@ jobs:
     secrets:
       AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
       AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}
-  trigger-deploy-to-integration:
-    name: Trigger deploy to integration
+  trigger-deploy:
+    name: Trigger deploy to ${{ github.event.inputs.environment }}
     needs: build-and-publish-image
     uses: alphagov/govuk-infrastructure/.github/workflows/deploy.yaml@main
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
       manualDeploy: ${{ 'main' != github.event.inputs.gitRef }}
+      environment: ${{ github.event.inputs.environment }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}


### PR DESCRIPTION
This adds a input specifying the environment in which to trigger a manual
deployment for. This shows an drop down when triggering workflow dispatch in
the GitHub UI. This functionality was added to simplify the process to rollback
a deployment i.e. deploying an previous release.
