### PR TITLE
Add new values for spam detection

### DIFF
--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -3,7 +3,7 @@ require "gds_api/support"
 class ReportAProblemTicket < Ticket
   SOURCE_WHITELIST = %w[mainstream inside_government page_not_found].freeze
 
-  attr_accessor :what_wrong, :what_doing, :giraffe, :referrer
+  attr_accessor :what_wrong, :what_doing, :giraffe, :referrer, :timer, :pastes, :keypresses
   attr_writer :page_owner, :javascript_enabled, :source
 
   validates :what_wrong, presence: true, if: proc { |ticket| ticket.what_doing.blank? }

--- a/app/models/report_a_problem_ticket.rb
+++ b/app/models/report_a_problem_ticket.rb
@@ -3,7 +3,7 @@ require "gds_api/support"
 class ReportAProblemTicket < Ticket
   SOURCE_WHITELIST = %w[mainstream inside_government page_not_found].freeze
 
-  attr_accessor :what_wrong, :what_doing, :giraffe, :referrer, :timer, :pastes, :keypresses
+  attr_accessor :what_wrong, :what_doing, :giraffe, :referrer, :timer
   attr_writer :page_owner, :javascript_enabled, :source
 
   validates :what_wrong, presence: true, if: proc { |ticket| ticket.what_doing.blank? }

--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -11,10 +11,6 @@ Rails.application.config.problem_report_spam_matchers = [
   ->(ticket) { ticket.giraffe.present? },
   # mark duplicate values in "what_wrong" and "what_doing" fields as spam
   ->(ticket) { ticket.what_wrong == ticket.what_doing },
-  # prevent a bot inserting text by modifying the DOM values
-  ->(ticket) { ticket.javascript_enabled && ticket.pastes.to_i.zero? && ticket.keypresses.to_i.zero? },
-  # prevent a bot only pasting and not typing anything
-  ->(ticket) { ticket.javascript_enabled && ticket.pastes.to_i.positive? && ticket.keypresses.to_i.zero? },
   # prevent a bot that might submit the form quickly
   ->(ticket) { ticket.javascript_enabled && ticket.timer.to_i <= 3 },
 ].freeze

--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -11,4 +11,10 @@ Rails.application.config.problem_report_spam_matchers = [
   ->(ticket) { ticket.giraffe.present? },
   # mark duplicate values in "what_wrong" and "what_doing" fields as spam
   ->(ticket) { ticket.what_wrong == ticket.what_doing },
+  # prevent a bot inserting text by modifying the DOM values
+  ->(ticket) { ticket.javascript_enabled && ticket.pastes.to_i.zero? && ticket.keypresses.to_i.zero? },
+  # prevent a bot only pasting and not typing anything
+  ->(ticket) { ticket.javascript_enabled && ticket.pastes.to_i.positive? && ticket.keypresses.to_i.zero? },
+  # prevent a bot that might submit the form quickly
+  ->(ticket) { ticket.javascript_enabled && ticket.timer.to_i <= 3 },
 ].freeze

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe ReportAProblemTicket, type: :model do
     it "should allow genuine submissions" do
       expect(ticket(what_doing: "browsing", what_wrong: "it broke")).to_not be_spam
       expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "4")).to_not be_spam
+      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "false", timer: "0")).to_not be_spam
     end
   end
 end

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -86,23 +86,14 @@ RSpec.describe ReportAProblemTicket, type: :model do
       expect(ticket(what_doing: "Lorem ipsum dolor sit amet", what_wrong: "Lorem ipsum dolor sit amet")).to be_spam
     end
 
-    it "should mark submissions that contain text but have 0 pastes or keypresses as spam" do
-      expect(ticket(what_doing: "Lorem ipsum", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "10", keypresses: "0", pastes: "0")).to be_spam
-    end
-
-    it "should mark submissions that contain text inserted via pastes and no keypresses as spam" do
-      expect(ticket(what_doing: "Lorem ipsum", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "10", keypresses: "0", pastes: "2")).to be_spam
-    end
-
     it "should mark submissions sent in three seconds or less as spam" do
-      expect(ticket(what_doing: "Lorem ipsum 1", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "0", keypresses: "20", pastes: "0")).to be_spam
-      expect(ticket(what_doing: "Lorem ipsum 2", what_wrong: "Lorem ipsum dolor sit", javascript_enabled: "true", timer: "3", keypresses: "20", pastes: "0")).to be_spam
+      expect(ticket(what_doing: "Lorem ipsum 1", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "0")).to be_spam
+      expect(ticket(what_doing: "Lorem ipsum 2", what_wrong: "Lorem ipsum dolor sit", javascript_enabled: "true", timer: "3")).to be_spam
     end
 
     it "should allow genuine submissions" do
       expect(ticket(what_doing: "browsing", what_wrong: "it broke")).to_not be_spam
-      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "50", keypresses: "50", pastes: "2")).to_not be_spam
-      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "50", keypresses: "50", pastes: "0")).to_not be_spam
+      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "4")).to_not be_spam
     end
   end
 end

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -86,8 +86,23 @@ RSpec.describe ReportAProblemTicket, type: :model do
       expect(ticket(what_doing: "Lorem ipsum dolor sit amet", what_wrong: "Lorem ipsum dolor sit amet")).to be_spam
     end
 
+    it "should mark submissions that contain text but have 0 pastes or keypresses as spam" do
+      expect(ticket(what_doing: "Lorem ipsum", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "10", keypresses: "0", pastes: "0")).to be_spam
+    end
+
+    it "should mark submissions that contain text inserted via pastes and no keypresses as spam" do
+      expect(ticket(what_doing: "Lorem ipsum", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "10", keypresses: "0", pastes: "2")).to be_spam
+    end
+
+    it "should mark submissions sent in three seconds or less as spam" do
+      expect(ticket(what_doing: "Lorem ipsum 1", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "0", keypresses: "20", pastes: "0")).to be_spam
+      expect(ticket(what_doing: "Lorem ipsum 2", what_wrong: "Lorem ipsum dolor sit", javascript_enabled: "true", timer: "3", keypresses: "20", pastes: "0")).to be_spam
+    end
+
     it "should allow genuine submissions" do
       expect(ticket(what_doing: "browsing", what_wrong: "it broke")).to_not be_spam
+      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "50", keypresses: "50", pastes: "2")).to_not be_spam
+      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "50", keypresses: "50", pastes: "0")).to_not be_spam
     end
   end
 end


### PR DESCRIPTION
Hi @gclssvglx 

Would you be able to look at this repo and check everything's OK?

I'll need the frontend deployed first before this is merged/continuously deployed, as this spam detection is dependent on the new values being present in the POST request, so I've marked it as `do not merge` for now. 

Thanks :+1:

## What

This incorporates form fields created via JavaScript, which provide metadata to help mark submissions on the feedback component as spam. The spam conditions are if:

- The submission contains text but has 0 keypresses or pastes (which would suggest a bot modified the `value` attribute of the HTML to insert their message)
- The submissions contains only pastes and no keypresses, which prevents someone just pasting spam into both boxes 
- The submission was submitted in 3 seconds or less

It makes use of the `javascript_enabled` boolean so the spam checks only run if JavaScript is enabled

## Why

This is an attempt to reduce spam coming through on the feedback form. We're aware it doesn't work when JS is disabled 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
