### PR TITLE
Fix missing environment when triggering CD in Argo

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -40,7 +40,7 @@ jobs:
     with:
       imageTag: ${{ needs.build-and-publish-image.outputs.imageTag }}
       manualDeploy: ${{ 'main' != github.event.inputs.gitRef }}
-      environment: ${{ github.event.inputs.environment }}
+      environment: ${{ github.event.inputs.environment || 'integration' }}
     secrets:
       WEBHOOK_TOKEN: ${{ secrets.ARGO_EVENTS_WEBHOOK_TOKEN }}
       WEBHOOK_URL: ${{ secrets.ARGO_EVENTS_WEBHOOK_URL }}


### PR DESCRIPTION
When the deploy workflow is triggered by a push to main (i.e. being
continuously deployed) an empty string is passed as the environment. This sets
a default environment of 'integration' instead of an empty string.
