### PR TITLE
Remove button component JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,4 @@
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/character-count
 //= require govuk_publishing_components/components/details
 //= require govuk_publishing_components/components/error-summary


### PR DESCRIPTION
## What

Remove include of the button component's JavaScript from this app's JavaScript.

## Why

This is now included in `static`'s JavaScript, so can be removed from this app.

## Visual changes

None.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
