### PR TITLE
Turn off font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,6 +2,11 @@ $govuk-compatibility-govuktemplate: false;
 $govuk-use-legacy-palette: false;
 $govuk-new-link-styles: true;
 
+// This flag stops the font from being included in this application's
+// stylesheet - the font is being served by Static across all of GOV.UK, so is
+// not needed here.
+$govuk-include-default-font-face: false;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/back-link";
 @import "govuk_publishing_components/components/character-count";


### PR DESCRIPTION
## What

Prevent the font from being included in `feedback`'s stylesheet.

## Why

We should be serving the font files from `static` so they're cached across the entirety of GOVUK - so the font shouldn't be included in `feedback`'s stylesheet.

With the font being served by each application, users need to re-download it every time they went from a page rendered in one application to a page rendered in another application.

Serving it from `static` means that the same font URI is used in each application, allowing the fonts to be cached and reused.

## Visual changes

None - the same font is being served from `static`, instead of `feedback`.

Before (the font paths contains `feedback`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181271872-68da552f-566f-4f20-bb20-60a16b5d8691.png">

After (the font path contains `static`):
<img width="1904" alt="" src="https://user-images.githubusercontent.com/87758239/181271934-18b913a2-3c32-462d-804d-e7ff2467ecfa.png">

---

## Search page examples to sanity check:

- https://feedback-pr-1471.herokuapp.com/contact/govuk