### PR TITLE
Remove request-accessible-format route from publishing_api Rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -22,15 +22,6 @@ namespace :publishing_api do
       rendering_app: "feedback",
     )
 
-    special_route_publisher.publish(
-      content_id: "34761d23-eafa-4025-82bf-0d127e06e8be",
-      title: "Request accessible format",
-      base_path: "/contact/govuk/request-accessible-format",
-      type: "exact",
-      publishing_app: "feedback",
-      rendering_app: "feedback",
-    )
-
     redirect_publisher = RedirectPublisher.new(
       logger: logger,
       publishing_app: "feedback",


### PR DESCRIPTION
This route is to be unpublished and marked as gone. To allow us to do
this, we are moving the route to [SpecialRoutePublisher](https://github.com/alphagov/special-route-publisher/pull/215). Should the
route be required again, it can be republished by SpecialRoutePublisher.

Removing it from this Rake task will prevent it accidentally being republished
via Feedback.

[trello](https://trello.com/c/tU8GEALb/1405-unpublish-request-accessible-format-form)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
