### PR TITLE
Update spam matcher

### DIFF
--- a/config/initializers/problem_report_spam_matchers.rb
+++ b/config/initializers/problem_report_spam_matchers.rb
@@ -12,5 +12,5 @@ Rails.application.config.problem_report_spam_matchers = [
   # mark duplicate values in "what_wrong" and "what_doing" fields as spam
   ->(ticket) { ticket.what_wrong == ticket.what_doing },
   # prevent a bot that might submit the form quickly
-  ->(ticket) { ticket.javascript_enabled && ticket.timer.to_i <= 3 },
+  ->(ticket) { ticket.javascript_enabled && ticket.timer.to_i <= 4 },
 ].freeze

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -86,14 +86,14 @@ RSpec.describe ReportAProblemTicket, type: :model do
       expect(ticket(what_doing: "Lorem ipsum dolor sit amet", what_wrong: "Lorem ipsum dolor sit amet")).to be_spam
     end
 
-    it "should mark submissions sent in three seconds or less as spam" do
+    it "should mark submissions sent in four seconds or less as spam" do
       expect(ticket(what_doing: "Lorem ipsum 1", what_wrong: "Lorem ipsum dolor sit amet", javascript_enabled: "true", timer: "0")).to be_spam
-      expect(ticket(what_doing: "Lorem ipsum 2", what_wrong: "Lorem ipsum dolor sit", javascript_enabled: "true", timer: "3")).to be_spam
+      expect(ticket(what_doing: "Lorem ipsum 2", what_wrong: "Lorem ipsum dolor sit", javascript_enabled: "true", timer: "4")).to be_spam
     end
 
     it "should allow genuine submissions" do
       expect(ticket(what_doing: "browsing", what_wrong: "it broke")).to_not be_spam
-      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "4")).to_not be_spam
+      expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "true", timer: "5")).to_not be_spam
       expect(ticket(what_doing: "browsing", what_wrong: "it broke", javascript_enabled: "false", timer: "0")).to_not be_spam
     end
   end


### PR DESCRIPTION
The problem_report_spam_matchers.rb previously would match on tickets submitted in under 3 seconds, as they suggested action by a bot. The recent second line shift received 2 spam messages via the feedback app, we can try increasing that
window by a second.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
