### PR TITLE
Replace Plek.current

### DIFF
--- a/config/initializers/support_app.rb
+++ b/config/initializers/support_app.rb
@@ -3,5 +3,5 @@ require "gds_api/support_api"
 
 support_token = ENV.fetch("SUPPORT_BEARER_TOKEN", "xxxxx")
 support_api_token = ENV.fetch("SUPPORT_API_BEARER_TOKEN", "xxxxx")
-Rails.application.config.support = GdsApi::Support.new(Plek.current.find("support"), bearer_token: support_token)
-Rails.application.config.support_api = GdsApi::SupportApi.new(Plek.current.find("support-api"), bearer_token: support_api_token)
+Rails.application.config.support = GdsApi::Support.new(Plek.find("support"), bearer_token: support_token)
+Rails.application.config.support_api = GdsApi::SupportApi.new(Plek.find("support-api"), bearer_token: support_api_token)

--- a/spec/requests/content_improvement_spec.rb
+++ b/spec/requests/content_improvement_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Content Improvement Feedback", type: :request do
   include GdsApi::TestHelpers::SupportApi
 
   let(:common_headers) { { "Accept" => "application/json", "Content-Type" => "application/json" } }
-  let(:support_api_url) { Plek.current.find("support-api") }
+  let(:support_api_url) { Plek.find("support-api") }
 
   it "submits the feedback to the support api" do
     stub_any_support_api_call
@@ -76,7 +76,7 @@ RSpec.describe "Content Improvement Feedback", type: :request do
          }.to_json,
          headers: common_headers
 
-    expected_request = a_request(:post, "#{Plek.current.find('support-api')}/anonymous-feedback/content_improvement")
+    expected_request = a_request(:post, "#{Plek.find('support-api')}/anonymous-feedback/content_improvement")
       .with(body: { "description" => "The title is the wrong colour." })
 
     expect(expected_request).to have_been_made

--- a/spec/requests/page_improvements_spec.rb
+++ b/spec/requests/page_improvements_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Page improvements", type: :request do
          }.to_json,
          headers: common_headers
 
-    expected_request = a_request(:post, "#{Plek.current.find('support-api')}/page-improvements")
+    expected_request = a_request(:post, "#{Plek.find('support-api')}/page-improvements")
       .with(body: {
         "description" => "The title is the wrong colour.",
         "url" => "https://gov.uk/path/to/page",
@@ -55,7 +55,7 @@ RSpec.describe "Page improvements", type: :request do
   end
 
   it "returns an error if the required attributes aren't supplied" do
-    url = "#{Plek.current.find('support-api')}/page-improvements"
+    url = "#{Plek.find('support-api')}/page-improvements"
     stub_request(:post, url)
       .with(body: {}.to_json)
       .to_return(
@@ -83,7 +83,7 @@ RSpec.describe "Page improvements", type: :request do
          }.to_json,
          headers: common_headers
 
-    expected_request = a_request(:post, "#{Plek.current.find('support-api')}/page-improvements")
+    expected_request = a_request(:post, "#{Plek.find('support-api')}/page-improvements")
       .with(body: { "description" => "The title is the wrong colour." })
 
     expect(expected_request).to have_been_made


### PR DESCRIPTION
`Plek.current` was marked as deprecated in alphagov/plek#94. This replaces all uses of `Plek.current` to stop deprecation warnings from filling up the logs with:

"Plek.current is deprecated and will be removed. Use Plek.new or Plek.find instead."

[Trello](https://trello.com/c/vdnZ4cBq/233-replace-plekcurrent)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
