### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "hiredis"
 gem "invalid_utf8_rejector"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "notifications-ruby-client"
 gem "plek"
 gem "rack-attack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,11 +188,8 @@ GEM
     loofah (2.19.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.8.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
-      net-imap
-      net-pop
-      net-smtp
     marcel (1.0.2)
     matrix (0.4.2)
     memoist (0.16.2)
@@ -434,6 +431,7 @@ DEPENDENCIES
   govuk_test
   hiredis
   invalid_utf8_rejector
+  mail (~> 2.7.1)
   notifications-ruby-client
   plek
   pry-byebug


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
