### PR TITLE
Replace archived govuk-content-schema-test-helpers with govuk_schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "uglifier"
 gem "valid_email"
 
 group :development, :test do
-  gem "govuk-content-schema-test-helpers"
+  gem "govuk_schemas"
   gem "govuk_test"
   gem "pry-byebug"
   gem "rails-controller-testing"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,9 +137,7 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
-    govuk_app_config (4.12.0)
+    govuk_app_config (4.11.1)
       logstasher (~> 2.1)
       plek (>= 4, < 6)
       prometheus_exporter (~> 2.0)
@@ -160,6 +158,8 @@ GEM
       rails (>= 6)
       rouge
       sprockets (>= 3)
+    govuk_schemas (4.5.0)
+      json-schema (>= 2.8, < 3.1)
     govuk_test (3.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -175,8 +175,8 @@ GEM
       concurrent-ruby (~> 1.0)
     invalid_utf8_rejector (0.0.4)
     json (2.6.2)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
+    json-schema (3.0.0)
+      addressable (>= 2.8)
     jwt (2.5.0)
     kgio (2.11.4)
     kramdown (2.4.0)
@@ -425,9 +425,9 @@ PLATFORMS
 DEPENDENCIES
   gds-api-adapters
   google-api-client
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_publishing_components
+  govuk_schemas
   govuk_test
   hiredis
   invalid_utf8_rejector

--- a/spec/lib/redirect_publisher_spec.rb
+++ b/spec/lib/redirect_publisher_spec.rb
@@ -1,12 +1,9 @@
 require "rails_helper"
 require "./app/lib/redirect_publisher"
-require "govuk-content-schema-test-helpers/rspec_matchers"
+require "govuk_schemas/rspec_matchers"
 
 RSpec.describe RedirectPublisher do
-  GovukContentSchemaTestHelpers.configure do |config|
-    config.schema_type = "publisher_v2"
-    config.project_root = Rails.root
-  end
+  RSpec.configuration.include GovukSchemas::RSpecMatchers
 
   let(:logger) { double(:logger) }
 
@@ -58,7 +55,7 @@ RSpec.describe RedirectPublisher do
     destination_path = "/contact"
 
     api = double(:publishing_api)
-    expect(api).to receive(:put_content).with(an_instance_of(String), be_valid_against_schema("redirect"))
+    expect(api).to receive(:put_content).with(an_instance_of(String), be_valid_against_publisher_schema("redirect"))
     expect(api).to receive(:publish).once.with(content_id)
 
     expect(logger).to receive(:info)


### PR DESCRIPTION
**What**

This is part of the work to replace all occurrences of [govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) with [govuk_schemas](https://github.com/alphagov/govuk_schemas).

**Why**

[govuk-content-schema-test-helpers](https://github.com/alphagov/govuk-content-schema-test-helpers) is deprecated, archived, and is no longer being updated. But is still used by [feedback](https://github.com/alphagov/feedback).

Link to [Trello](https://trello.com/c/fOfPOszp/237-switch-govuk-content-schema-test-helpers-for-govukschemas-in-feedback) card

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
