### PR TITLE
Remove workaround for bad `mail` gem release.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,6 @@ gem "govuk_app_config"
 gem "govuk_publishing_components"
 gem "hiredis"
 gem "invalid_utf8_rejector"
-gem "mail", "~> 2.8.0"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "notifications-ruby-client"
 gem "plek"
 gem "rack-attack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,7 +438,6 @@ DEPENDENCIES
   govuk_test
   hiredis
   invalid_utf8_rejector
-  mail (~> 2.8.0)
   notifications-ruby-client
   plek
   pry-byebug


### PR DESCRIPTION
Remove the version constraint that we were using to avoid the bad release of the `mail` gem, now that https://www.github.com/mikel/mail/issues/1489 is fixed.

Update to `2.8.0.1`, which fixes the permissions issue.

Generated with `gsed -i '/gem "mail"/d' && bundle update mail`.
