### PR TITLE
Ignore Ruby 2.7.6 warning while Ruby 3 upgrade happens

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,22 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.6 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 248,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": ""
+    }
+  ],
+  "updated": "2023-01-31 13:49:35 +0000",
+  "brakeman_version": "5.2.3"
+}


### PR DESCRIPTION
I ran `bundle exec brakeman -I` which allowed me to create a config file to ignore warnings. The warning in question is Ruby 2.7.6 is EOL. Therefore adding this file allows our GitHub tests to pass while the Ruby 3 upgrade takes place.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
