### PR TITLE
Configure AssetHelper to load individual stylesheets

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,10 +1,4 @@
-$govuk-compatibility-govuktemplate: false;
-$govuk-use-legacy-palette: false;
-$govuk-new-link-styles: true;
+// The AssetHelper module is configured for this application to load individual stylesheets
+// for components and views on pages where they are needed.
 
-// This flag stops the font from being included in this application's
-// stylesheet - the font is being served by Static across all of GOV.UK, so is
-// not needed here.
-$govuk-include-default-font-face: false;
-
-
+// https://github.com/alphagov/govuk_publishing_components/blob/main/docs/set-up-individual-component-css-loading.md

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,14 +7,4 @@ $govuk-new-link-styles: true;
 // not needed here.
 $govuk-include-default-font-face: false;
 
-@import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/components/back-link";
-@import "govuk_publishing_components/components/character-count";
-@import "govuk_publishing_components/components/details";
-@import "govuk_publishing_components/components/document-list";
-@import "govuk_publishing_components/components/error-summary";
-@import "govuk_publishing_components/components/fieldset";
-@import "govuk_publishing_components/components/inset-text";
-@import "govuk_publishing_components/components/panel";
-@import "govuk_publishing_components/components/radio";
-@import "govuk_publishing_components/components/warning-text";
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,3 +1,20 @@
+<% content_for :body do %>
+  <div id="wrapper">
+    <%= render 'govuk_publishing_components/components/breadcrumbs', {
+      breadcrumbs: @breadcrumbs,
+      collapse_on_mobile: true
+    } %>
+    <main id="content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <%= render 'govuk_publishing_components/components/title', title: yield(:title) %>
+          <%= yield %>
+        </div>
+      </div>
+    </main>
+  </div>
+<% end %>
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -5,23 +22,14 @@
     <%=  stylesheet_link_tag 'application', :media => "all", integrity: false %>
     <title><%= yield :title %> - GOV.UK</title>
     <%= yield :section_meta_tags %>
+    <%=
+      render_component_stylesheets
+    %>
   </head>
   <body>
-    <div id="wrapper">
-      <%= render 'govuk_publishing_components/components/breadcrumbs', {
-        breadcrumbs: @breadcrumbs,
-        collapse_on_mobile: true
-      } %>
-      <main id="content" role="main">
-        <div class="govuk-grid-row">
-          <div class="govuk-grid-column-two-thirds">
-            <%= render 'govuk_publishing_components/components/title', title: yield(:title) %>
-            <%= yield %>
-          </div>
-        </div>
-      </main>
-    </div>
+    <%= yield :body %>
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
     <%= javascript_include_tag 'application', integrity: false %>
   </body>
 </html>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <%=  stylesheet_link_tag 'application', :media => "all", integrity: false %>
     <title><%= yield :title %> - GOV.UK</title>
     <%= yield :section_meta_tags %>
     <%=


### PR DESCRIPTION
## What

https://trello.com/c/76GY8acK/1906-enable-individual-loading-of-stylesheets-in-feedback

Changes to load component and view style sheets only required on the page being viewed. For example, CSS for "radio" only loads on the following pages:

- https://www.integration.publishing.service.gov.uk/contact/govuk

## Why

This reduces the amount of CSS required for each page and increases the ability of a browser to cache the stylesheets - this should mean a faster load time for both first time and repeat visitors.

See [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152) for more details.

## Review URL(s)

- https://www.integration.publishing.service.gov.uk/contact
- https://www.integration.publishing.service.gov.uk/contact/govuk
- https://www.integration.publishing.service.gov.uk/contact/govuk/thankyou
- https://www.integration.publishing.service.gov.uk/contact/govuk/anonymous-feedback/thankyou

## Visual changes

None

## Anything else
- `application.scss` only includes the following settings (below) which can be removed since they are included with `_individual_component_support.scss` (imported from `govuk_publishing_components`) and `application.scss` can then be removed

```
$govuk-new-link-styles: true;
$govuk-include-default-font-face: false;
```

- https://github.com/alphagov/govuk_publishing_components/pull/3014
- https://github.com/alphagov/frontend/pull/3342
- https://github.com/alphagov/smart-answers/pull/6213
- [RFC #149](https://github.com/alphagov/govuk-rfcs/pull/152)