### PR TITLE
Update 'Do you want a reply?' legend

### DIFF
--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -93,7 +93,7 @@
     } %>
 
     <%= render "govuk_publishing_components/components/fieldset", {
-      legend_text: "Do you want a reply?",
+      legend_text: "If you want a reply (optional)",
       heading_size: "m"
     } do %>
       <p class="govuk-body">If you'd like us to get back to you, please leave your details below.</p>


### PR DESCRIPTION
Hi @JamesCGDS, would you be able to approve this? Thanks :+1:

## What

Changes the text of a form legend.

## Why

https://trello.com/c/iTgnGdDc/249-optional-form-fields-cannot-be-identified-by-users

On this page https://gov.uk/contact/govuk under the "Do you want a reply?" section, the "optional" behaviour of the fields is a bit confusing. 

If both "Your name" and "Your email address" are empty, then the fields are treated as optional so the form will submit successfully. However, if you just populate "Your name" then the "Your email address" field becomes required. Or if you populate the "Your email address" field, then the "Your name" field becomes required. This can cause confusion, so was flagged as an accessibility issue.

Therefore, this new legend hopes to make it clearer that the whole fieldset is optional. The new legend was suggested by a content lead in our accessibility community channel.

## Visual Changes

### Before
<img width="690" alt="image" src="https://user-images.githubusercontent.com/8880610/230132132-2ca217a8-8ade-4149-b224-a2d44d134792.png">

### After
<img width="690" alt="image" src="https://user-images.githubusercontent.com/8880610/230132175-a63b435e-c117-44ab-98ee-f56b1f4c43b9.png">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
