### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,44 @@ submitted via an anonymous contact form.
 via a form that will require you to identify yourself. This data is sent directly
 to the support app.
 
+## Completed Transaction feedback forms
+
+### Service Feedback
+Most of the `/done/completed-transaction` pages render a Service Feedback form. An example is: [www.gov.uk/done/vehicle-tax](http://www.gov.uk/done/vehicle-tax). 
+
+### Assisted Digital Feedback
+There are also three assisted digital feedback forms:
+
+- https://www.gov.uk/done/register-flood-risk-exemption
+- https://www.gov.uk/done/waste-carrier-or-broker-registration
+- https://www.gov.uk/done/register-waste-exemption
+
+### Transaction finished
+
+The transaction finished page can be found here: https://www.gov.uk/done/transaction-finished.
+This doesn’t display a form, just content to inform the user that the transaction is finished.
+
+### Where is the data sent?
+
+The Service Feedback form fields also exist within the Assisted Digital Feedback form. They are foundationally the same, but Assisted Digital Feedback has some extra fields.
+
+The Service Feedback form data from both types of form is sent to the Support API. It can be viewed using the Support app within the Feedback Explorer.
+
+In addition to sending some data to the Support API, the data from the other fields (from the Assisted Digital Feedback form) plus some data from hidden fields appended using JS (`referrer` and `javascript_enabled`) are written to a Google spreadsheet.
+
+For submitting the Assisted Digital Feedback form, you will need to get the Google API credentials from AWS secrets/integration. To use them locally, create a .dotenv file and write them in:
+
+```
+GOOGLE_PRIVATE_KEY=
+GOOGLE_CLIENT_EMAIL=
+ASSISTED_DIGITAL_GOOGLE_SPREADSHEET_KEY=
+``` 
+
+The `.env` file is listed within the `.gitignore` file. Do not push the `.env` file to version control.
+
+Completed transaction feedback forms were previously rendered by the Frontend application. [Rendering was moved into this application](https://github.com/alphagov/feedback/pull/1601) which enabled the implementation of form validation. 
+
+
 ## Technical documentation
 
 This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).


### PR DESCRIPTION
[Trello](https://trello.com/c/VHZ1R1zY/262-no-form-validation-on-service-feedback-forms-l)

Add documentation about the completed transaction feedback forms to the README. The rendering of these forms was recently moved from Frontend to the Feedback application[1].

[1](https://github.com/alphagov/feedback/pull/1601).



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
