### PR TITLE
Fix empty email address validation issue

### DIFF
--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -29,7 +29,7 @@ module Contact
 
       def confirm_submission
         if ajax_request?
-          render json: { message: "email survey sign up success" }, status: :ok
+          render json: { message: "email survey sign up success" }, status: :created
         else
           redirect_to contact_anonymous_feedback_thankyou_path
         end

--- a/app/controllers/contact/govuk/email_survey_signup_controller.rb
+++ b/app/controllers/contact/govuk/email_survey_signup_controller.rb
@@ -59,7 +59,7 @@ module Contact
     private
 
       def ajax_request?
-        request.xhr? || request.format == :js
+        request.xhr? || request.format.json?
       end
     end
   end

--- a/app/controllers/contact/govuk/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk/problem_reports_controller.rb
@@ -39,7 +39,7 @@ class Contact::Govuk::ProblemReportsController < ContactController
         # and replace what the app sends back with a standard error page
         render "contact/govuk/problem_reports/thankyou"
       end
-      format.js do
+      format.json do
         response = { message: @message, status: status_text }
         response[:errors] = ticket.errors.full_messages unless ticket.valid?
 

--- a/app/controllers/contact/govuk/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk/problem_reports_controller.rb
@@ -2,8 +2,8 @@ class Contact::Govuk::ProblemReportsController < ContactController
   DONE_OK_TEXT = "<h1 class='govuk-heading-l'>Thank you for your help.</h1> " \
     "<p class='govuk-body'>If you have more extensive feedback, " \
     "please visit the <a class='govuk-link' href='/contact'>contact page</a>.</p>".freeze
-  DONE_INVALID_TEXT = "<h1 class='govuk-heading-l'>Sorry, we're unable to send your message as you haven't given us any information.</h1> " \
-    "<p class='govuk-body'>Please tell us what you were doing or what went wrong.</p>".freeze
+  DONE_INVALID_TEXT = "<h2>Sorry, we're unable to send your message as you haven't given us any information.</h2> " \
+    "<p>Please tell us what you were doing or what went wrong.</p>".freeze
 
   def create
     attributes = params.merge(technical_attributes)

--- a/app/controllers/contact/govuk/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk/problem_reports_controller.rb
@@ -21,7 +21,7 @@ class Contact::Govuk::ProblemReportsController < ContactController
 
       hide_report_a_problem_form_in_response
       @message = DONE_OK_TEXT.html_safe
-      status = 201
+      status = :created
       status_text = "success"
       GovukStatsd.increment("report_a_problem.successful_submission")
     else

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,6 @@ Rails.application.routes.draw do
 
       post "problem_reports", to: "problem_reports#create", format: false
       post "email-survey-signup", to: "email_survey_signup#create", format: false
-      post "email-survey-signup.js", to: "email_survey_signup#create", defaults: { format: :js }
       post "content_improvement", to: "content_improvement#create", defaults: { format: :js }
       resources "page_improvements", only: [:create], format: false
       get "request-accessible-format", to: "accessible_format_requests#start_page", format: false

--- a/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
+++ b/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Contact::Govuk::ProblemReportsController, type: :controller do
                  javascript_enabled: "true",
                  referrer: "https://www.gov.uk/some-url/",
                }.merge(attrs),
-               xhr: true
+               as: :json
         end
 
         it "should save the ticket" do

--- a/spec/requests/email_survey_signup_request_spec.rb
+++ b/spec/requests/email_survey_signup_request_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
 
   context "for a JS request" do
     it "responds inline with a 200 ok success message" do
-      submit_email_survey_sign_up as_js: true
+      submit_email_survey_sign_up as_json: true
 
       expect(response).to have_http_status(:ok)
       expect(response.media_type).to eq("application/json")
@@ -85,7 +85,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
     end
 
     it "responds with a 422 failure for invalid submissions" do
-      submit_email_survey_sign_up as_js: true, params: {}
+      submit_email_survey_sign_up as_json: true, params: {}
 
       expect(response).to have_http_status(:unprocessable_entity)
       expect(response.media_type).to eq("application/json")
@@ -99,7 +99,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
       stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email")
         .to_return(status: 403, body: '{"errors":[{"error":403,"message":"forbidden"}]}')
 
-      submit_email_survey_sign_up as_js: true
+      submit_email_survey_sign_up as_json: true
 
       expect(response).to have_http_status(:service_unavailable)
       expect(response.media_type).to eq("application/json")
@@ -122,13 +122,14 @@ RSpec.describe "Email survey sign-up request", type: :request do
     expect(notify_request).to have_been_requested
   end
 
-  def submit_email_survey_sign_up(params: valid_params, headers: {}, as_xhr: false, as_js: false)
+  def submit_email_survey_sign_up(params: valid_params, headers: {}, as_xhr: false, as_json: false)
     url = "/contact/govuk/email-survey-signup"
 
     if as_xhr
       post url, params:, headers:, xhr: true
+    elsif as_json
+      post url, params:, headers:, as: :json
     else
-      url << ".js" if as_js
       post url, params:, headers:
     end
   end

--- a/spec/requests/email_survey_signup_request_spec.rb
+++ b/spec/requests/email_survey_signup_request_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
     it "responds inline with a 200 ok success message" do
       submit_email_survey_sign_up as_xhr: true
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:created)
       expect(response.media_type).to eq("application/json")
       expect(JSON.parse(response.body)).to eq("message" => "email survey sign up success")
     end
@@ -79,7 +79,7 @@ RSpec.describe "Email survey sign-up request", type: :request do
     it "responds inline with a 200 ok success message" do
       submit_email_survey_sign_up as_json: true
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:created)
       expect(response.media_type).to eq("application/json")
       expect(JSON.parse(response.body)).to eq("message" => "email survey sign up success")
     end


### PR DESCRIPTION
## What

Change the expected request format from JS to JSON to fix an issue in the feedback component where the Email Survey Signup form can be submitted with an empty email address.

**Depends on:**
- https://github.com/alphagov/govuk_publishing_components/issues/2539

## Why

- It appears that XMLHttpRequest (XHR) submissions from both the form Email Survey Sign up form and the Report a Problem form in the feedback component have the request format `*/*` (with JavaScript disabled the default format is `text/html`)
- Also, `request.xhr?` seems to only return true if:

```
the X-Requested-With header contains “XMLHttpRequest” (case-insensitive), which may need to be manually added depending on the choice of JavaScript libraries and frameworks
```
See https://api.rubyonrails.org//classes/ActionDispatch/Request.html#method-i-xml_http_request-3F. However, adding this header has no effect and has been looked at previously https://github.com/alphagov/feedback/commit/9c10bf4860738d776c676b1b04fbf9ff9eacd7ae

- I've therefore added the Accept request HTTP header (with the XHR request headers) to indicate the the content type of JSON. _Rails determines the desired response format from the HTTP Accept header submitted by the client_. See https://api.rubyonrails.org//classes/ActionController/MimeResponds.html#method-i-respond_to.

## Anything else

See https://github.com/alphagov/govuk_publishing_components/issues/2539