### PR TITLE
Fix formatting of the completed transaction slugs

### DIFF
--- a/app/controllers/assisted_digital_feedback_controller.rb
+++ b/app/controllers/assisted_digital_feedback_controller.rb
@@ -4,7 +4,7 @@ class AssistedDigitalFeedbackController < ContactController
 
   before_action :set_locale, if: -> { request.format.html? }
 
-  LEGACY_SLUGS = [
+  LEGACY_BASE_PATHS = [
     "done/transaction-finished",
     "done/driving-transaction-finished",
   ].freeze
@@ -70,7 +70,7 @@ private
   end
 
   def show_survey?
-    LEGACY_SLUGS.exclude?(params[:slug])
+    LEGACY_BASE_PATHS.exclude?(params[:slug])
   end
 
   def handle_form_errors

--- a/app/controllers/service_feedback_controller.rb
+++ b/app/controllers/service_feedback_controller.rb
@@ -3,7 +3,7 @@ class ServiceFeedbackController < ContactController
   # These 2 legacy completed transactions are linked to from multiple
   # transactions. The user satisfaction survey should not be shown for these as
   # it would generate noisy data for the linked organisation.
-  LEGACY_SLUGS = [
+  LEGACY_BASE_PATHS = [
     "done/transaction-finished",
     "done/driving-transaction-finished",
   ].freeze
@@ -69,7 +69,7 @@ private
   end
 
   def show_survey?
-    LEGACY_SLUGS.exclude?(params[:slug])
+    LEGACY_BASE_PATHS.exclude?(params[:base_path])
   end
 
   def handle_form_errors

--- a/app/helpers/service_feedback_helper.rb
+++ b/app/helpers/service_feedback_helper.rb
@@ -23,7 +23,7 @@ private
     @completed_transaction_content_item ||= request.env[:content_item] || request_content_item
   end
 
-  def request_content_item(base_path = "/#{params[:slug]}")
+  def request_content_item(base_path = "/#{params[:base_path]}")
     GdsApi.content_store.content_item(base_path)
   end
 end

--- a/app/lib/format_routing_constraint.rb
+++ b/app/lib/format_routing_constraint.rb
@@ -11,10 +11,10 @@ class FormatRoutingConstraint
   def set_content_item(request)
     return request.env[:content_item] if already_cached?(request)
 
-    slug = request.params.fetch(:slug)
+    base_path = request.params.fetch(:base_path)
 
     begin
-      request.env[:content_item] = GdsApi.content_store.content_item("/#{slug}")
+      request.env[:content_item] = GdsApi.content_store.content_item("/#{base_path}")
     rescue GdsApi::HTTPErrorResponse, GdsApi::InvalidUrl => e
       request.env[:content_item_error] = e
       nil

--- a/app/presenters/content_item_presenter.rb
+++ b/app/presenters/content_item_presenter.rb
@@ -26,7 +26,7 @@ class ContentItemPresenter
   end
 
   def slug
-    URI.parse(base_path).path.sub(%r{\A/}, "")
+    base_path.split("/").last
   end
 
   def format

--- a/app/views/assisted_digital_feedback/_assisted_digital_satisfaction_survey.html.erb
+++ b/app/views/assisted_digital_feedback/_assisted_digital_satisfaction_survey.html.erb
@@ -5,8 +5,8 @@
   margin_bottom: 4
 } %>
 
-<form action=<%= "#{publication.slug.gsub("done/", "")}" %> method="post" data-module="transaction-survey-form" class="service-feedback">
-  <input type="hidden" id="service_slug" name="service_feedback[slug]" value=<%= publication.slug %>/>
+<form action=<%= publication.slug %> method="post" data-module="transaction-survey-form" class="service-feedback">
+  <input type="hidden" id="service_slug" name="service_feedback[slug]" value=<%= publication.slug %>>
   <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= publication.web_url %>" />
   <%= render partial: "shared/spam_honeypot", locals: { form_name: "service_feedback" } %>
 

--- a/app/views/service_feedback/_standard_satisfaction_survey.html.erb
+++ b/app/views/service_feedback/_standard_satisfaction_survey.html.erb
@@ -5,8 +5,8 @@
   margin_bottom: 4
 } %>
 
-<form action=<%= "#{publication.slug.gsub("done/", "")}" %> method="post" data-module="transaction-survey-form" class="service-feedback">
-  <input type="hidden" id="service_slug" name="service_feedback[slug]" value=<%= publication.slug %>/>
+<form action=<%= publication.slug %> method="post" data-module="transaction-survey-form" class="service-feedback">
+  <input type="hidden" id="service_slug" name="service_feedback[slug]" value=<%= publication.slug %>>
   <input type="hidden" id="service_done_page_url" name="service_feedback[url]" value="<%= publication.web_url %>" />
   <%= render partial: "shared/spam_honeypot", locals: { form_name: "service_feedback" } %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,15 +7,15 @@ Rails.application.routes.draw do
   get "/contact", format: false, to: "contact#index"
 
   constraints FormatRoutingConstraint.new("completed_transaction") do
-    get "*slug", slug: %r{done/register-flood-risk-exemption}, to: "assisted_digital_feedback#new"
-    post "*slug", slug: %r{done/register-flood-risk-exemption}, to: "assisted_digital_feedback#create"
-    get "*slug", slug: %r{done/waste-carrier-or-broker-registration}, to: "assisted_digital_feedback#new"
-    post "*slug", slug: %r{done/waste-carrier-or-broker-registration}, to: "assisted_digital_feedback#create"
-    get "*slug", slug: %r{done/register-waste-exemption}, to: "assisted_digital_feedback#new"
-    post "*slug", slug: %r{done/register-waste-exemption}, to: "assisted_digital_feedback#create"
+    get "*base_path", base_path: %r{done/register-flood-risk-exemption}, to: "assisted_digital_feedback#new"
+    post "*base_path", base_path: %r{done/register-flood-risk-exemption}, to: "assisted_digital_feedback#create"
+    get "*base_path", base_path: %r{done/waste-carrier-or-broker-registration}, to: "assisted_digital_feedback#new"
+    post "*base_path", base_path: %r{done/waste-carrier-or-broker-registration}, to: "assisted_digital_feedback#create"
+    get "*base_path", base_path: %r{done/register-waste-exemption}, to: "assisted_digital_feedback#new"
+    post "*base_path", base_path: %r{done/register-waste-exemption}, to: "assisted_digital_feedback#create"
 
-    get "*slug", slug: %r{done/.+}, to: "service_feedback#new"
-    post "*slug", slug: %r{done/.+}, to: "service_feedback#create"
+    get "*base_path", base_path: %r{done/.+}, to: "service_feedback#new"
+    post "*base_path", base_path: %r{done/.+}, to: "service_feedback#create"
   end
 
   namespace :contact do

--- a/spec/helpers/service_feedback_helper_spec.rb
+++ b/spec/helpers/service_feedback_helper_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ServiceFeedbackHelper, type: :helper do
 
   let(:payload) do
     {
-      base_path: slug,
+      base_path:,
       schema_name: "completed_transaction",
       document_type: "completed_transaction",
       external_related_links: [],
@@ -15,17 +15,17 @@ RSpec.describe ServiceFeedbackHelper, type: :helper do
     }
   end
 
-  let(:slug) { "done/some-transaction" }
+  let(:base_path) { "/done/some-transaction" }
 
   before do
-    stub_content_store_has_item("/#{slug}", payload)
-    params[:slug] = slug
+    stub_content_store_has_item("/#{base_path}", payload)
+    params[:base_path] = base_path
   end
 
   describe "#content_item_hash" do
     it "returns a hash of content item data" do
       expect(helper.content_item_hash).to eql({
-        "base_path" => slug,
+        "base_path" => base_path,
         "document_type" => "completed_transaction",
         "external_related_links" => [],
         "schema_name" => "completed_transaction",
@@ -43,7 +43,7 @@ RSpec.describe ServiceFeedbackHelper, type: :helper do
   describe "set_locale" do
     it "sets the default locale to Welsh when locale is cy" do
       payload.merge!({ locale: "cy" })
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
 
       expect(helper.set_locale).to eql("cy")
     end

--- a/spec/lib/format_routing_constraint_spec.rb
+++ b/spec/lib/format_routing_constraint_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe FormatRoutingConstraint do
     context "when the content_store returns a document" do
       before do
         @format = "completed_transaction"
-        stub_content_store_has_item("/#{slug}", schema_name: @format)
+        stub_content_store_has_item("/#{base_path}", schema_name: @format)
         @request = request
       end
 
@@ -30,7 +30,7 @@ RSpec.describe FormatRoutingConstraint do
 
     context "when the content_store API call throws an error" do
       before do
-        stub_content_store_does_not_have_item("/#{slug}")
+        stub_content_store_does_not_have_item("/#{base_path}")
         @request = request
       end
 
@@ -47,11 +47,11 @@ RSpec.describe FormatRoutingConstraint do
     end
   end
 
-  def slug
+  def base_path
     "done/some-transaction"
   end
 
   def request
-    double({ params: { slug: }, env: {} })
+    double({ params: { base_path: }, env: {} })
   end
 end

--- a/spec/models/assisted_digital_feedback_spec.rb
+++ b/spec/models/assisted_digital_feedback_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AssistedDigitalFeedback, type: :model do
   include GdsApi::TestHelpers::ContentStore
 
   before do
-    stub_content_store_has_item("/#{slug}", schema_name: format)
+    stub_content_store_has_item("/#{base_path}", schema_name: format)
   end
 
   context "a minimal valid feedback item" do
@@ -375,7 +375,7 @@ RSpec.describe AssistedDigitalFeedback, type: :model do
     "completed_transaction"
   end
 
-  def slug
+  def base_path
     "done/some-transaction"
   end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -4,7 +4,7 @@ require "gds_api/test_helpers/content_store"
 
 RSpec.describe ContentItemPresenter do
   include GdsApi::TestHelpers::ContentStore
-  let(:slug) { "done/some-transaction" }
+  let(:base_path) { "done/some-transaction" }
   let(:payload) do
     {
       base_path: "/done/some-transaction",
@@ -98,7 +98,7 @@ RSpec.describe ContentItemPresenter do
   end
 
   def setup_content_item_presenter
-    stub_content_store_has_item("/#{slug}", payload)
+    stub_content_store_has_item("/#{base_path}", payload)
     content_item_presenter
   end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe ContentItemPresenter do
   end
 
   it "presents the slug" do
-    expect(content_item_presenter.slug).to eql("done/some-transaction")
+    expect(content_item_presenter.slug).to eql("some-transaction")
   end
 
   it "presents the format" do

--- a/spec/requests/assisted_digital_spec.rb
+++ b/spec/requests/assisted_digital_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
   end
 
   before do
-    stub_content_store_has_item("/#{slug}", schema_name: format)
+    stub_content_store_has_item("/#{base_path}", schema_name: format)
     stub_request(:post, %r{https://sheets.googleapis.com/v4/spreadsheets/*})
     stub_support_api_service_feedback_creation
     # Set auth to nil, and this won't try to incur extra requests
@@ -27,7 +27,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
 
   context "render an Assisted Digital Feedback form" do
     it "displays title from the completed transaction's content item" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_content("Some Transaction")
@@ -37,7 +37,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     include_examples "Service Feedback", "/done/register-flood-risk-exemption"
 
     it "displays did you receive assistance radio buttons" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_field("Yes", type: "radio")
@@ -45,7 +45,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays service satisfaction rating radio buttons" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.online_satisfaction_check"))
@@ -57,21 +57,21 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays service feedback improvement comments text area" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       expect(page).to have_field(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.how_improve", type: "textarea"))
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.no_pii_hint"))
     end
 
     it "displays What assistance did you receive? text area" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_field(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.what_assistance"), type: "textarea")
     end
 
     it "displays Who provided the assistance? radio buttons" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.who_assisted"))
@@ -82,7 +82,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays How satisfied are you with the assistance received? (government staff) radio buttons" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.satisfaction_check"))
@@ -95,21 +95,21 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays how could we improve this service? (government staff) text area" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_field("service_feedback[assistance_improvement_comments]", type: "textarea")
     end
 
     it "displays tell us who the other person was? (other) text input" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_field(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.other_person"), type: "text")
     end
 
     it "displays How satisfied are you with the assistance received? (other) radio buttons" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.assisted_digital_feedback.satisfaction_check"))
@@ -121,7 +121,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays how could we improve this service? (other) text area" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_field("service_feedback[assistance_improvement_comments_other]", type: "textarea")
@@ -129,7 +129,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
 
     it "displays Welsh translation when locale is set to cy" do
       payload.merge!({ locale: "cy" })
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
 
       expect(page).to have_content "Helpwch ni i wella'r gwasanaeth hwn"
@@ -141,7 +141,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
       stub_support_api_service_feedback_creation(
         service_satisfaction_rating: 5,
         details: "Test",
-        slug: "/done/register-flood-risk-exemption",
+        slug: "register-flood-risk-exemption",
         user_agent: nil,
         javascript_enabled: false,
         referrer: "https://www.some-transaction.service.gov/uk/completed",
@@ -151,7 +151,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "submits with valid data" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       choose("service_feedback[assistance_received]", option: "no")
       choose("service_feedback[service_satisfaction_rating]", option: "5")
@@ -162,7 +162,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays an error message when all fields are blank" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       click_on I18n.translate("controllers.contact.govuk.assisted_digital_feedback.send_feedback")
 
@@ -172,7 +172,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays an error message when assistance was not needed and fields are blank" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       choose("service_feedback[assistance_received]", option: "no")
       click_on I18n.translate("controllers.contact.govuk.assisted_digital_feedback.send_feedback")
@@ -182,7 +182,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
 
     it "displays an error message when assistance was not needed and How could we improve this service is too long" do
       long_comment = "a" * 1255
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "no")
@@ -195,7 +195,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays an error message when assistance was needed and fields are blank" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "yes")
@@ -210,7 +210,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
 
     it "displays an error message when assistance was needed and What assistance did you receive? is too long" do
       long_comment = "a" * 1255
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "yes")
@@ -222,7 +222,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays an error message when assistance was provided by government staff and the government staff section is blank" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "yes")
@@ -237,7 +237,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
 
     it "displays an error message when assistance was provided by government staff and how could we improve this service? is too long" do
       long_comment = "a" * 1255
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "yes")
@@ -251,7 +251,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     end
 
     it "displays an error message when assistance was provided by other and fields are blank" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "yes")
@@ -267,7 +267,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
 
     it "displays an error message when assistance was provided by other and How could we improve this service? is too long" do
       long_comment = "a" * 1255
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/register-flood-risk-exemption")
       within(".service-feedback") do
         choose("service_feedback[assistance_received]", option: "yes")
@@ -424,7 +424,7 @@ RSpec.describe "Assisted digital help with fees submission", type: :request do
     "completed_transaction"
   end
 
-  def slug
+  def base_path
     "done/register-flood-risk-exemption"
   end
 end

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -19,12 +19,12 @@ RSpec.describe "Service feedback submission", type: :request do
   end
 
   before do
-    stub_content_store_has_item("/#{slug}", schema_name: format)
+    stub_content_store_has_item("/#{base_path}", schema_name: format)
   end
 
   context "render a Service Feedback form" do
     it "displays title from the completed transaction's content item" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
 
       expect(page).to have_content("Some Transaction")
@@ -34,7 +34,7 @@ RSpec.describe "Service feedback submission", type: :request do
     include_examples "Service Feedback", "/done/some-transaction"
 
     it "displays service satisfaction rating radio buttons" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
 
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.service_feedback.service_satisfaction_rating"))
@@ -46,7 +46,7 @@ RSpec.describe "Service feedback submission", type: :request do
     end
 
     it "displays service feedback improvement comments text area" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
       expect(page).to have_field(I18n.translate("controllers.contact.govuk.service_feedback.how_improve", type: "textarea"))
       expect(page).to have_content(I18n.translate("controllers.contact.govuk.service_feedback.no_pii_hint"))
@@ -59,7 +59,7 @@ RSpec.describe "Service feedback submission", type: :request do
     end
 
     it "submits with valid data" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
       within(".service-feedback") do
         choose I18n.translate("controllers.contact.govuk.service_feedback.very_satisfied")
@@ -70,7 +70,7 @@ RSpec.describe "Service feedback submission", type: :request do
     end
 
     it "displays validation error when Service Satisfaction Rating is blank" do
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
       within(".service-feedback") do
         fill_in I18n.translate("controllers.contact.govuk.service_feedback.how_improve"), with: "Test"
@@ -81,7 +81,7 @@ RSpec.describe "Service feedback submission", type: :request do
 
     it "displays validation error when Service Improvement comments exceeds maximum character count" do
       long_comment = "a" * 1255
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
       within(".service-feedback") do
         choose I18n.translate("controllers.contact.govuk.service_feedback.very_satisfied")
@@ -94,7 +94,7 @@ RSpec.describe "Service feedback submission", type: :request do
 
     it "displays Welsh translation when locale is set to cy" do
       payload.merge!({ locale: "cy" })
-      stub_content_store_has_item("/#{slug}", payload)
+      stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")
 
       expect(page).to have_content "Arolwg boddhad"
@@ -213,7 +213,7 @@ RSpec.describe "Service feedback submission", type: :request do
     "completed_transaction"
   end
 
-  def slug
+  def base_path
     "done/some-transaction"
   end
 end

--- a/spec/support/service_feedback.rb
+++ b/spec/support/service_feedback.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples_for "Service Feedback" do |path|
   it "displays no promotion when there is no promotion choice" do
-    stub_content_store_has_item("/#{slug}", payload)
+    stub_content_store_has_item(path, payload)
     visit(path)
 
     expect(page).not_to have_selector(".promotion")
@@ -51,12 +51,12 @@ RSpec.shared_examples_for "Service Feedback" do |path|
     expect(page).to have_content(I18n.translate("controllers.contact.govuk.service_feedback.mot_reminder.title"))
   end
 
-  it "does not show survey for legacy slugs" do
-    do_not_show_survey_for_legacy_slugs_payload = payload.merge({
+  it "does not show survey for legacy base paths" do
+    do_not_show_survey_for_legacy_base_paths_payload = payload.merge({
       base_path: "/done/transaction-finished",
     })
 
-    stub_content_store_has_item("/done/transaction-finished", do_not_show_survey_for_legacy_slugs_payload)
+    stub_content_store_has_item("/done/transaction-finished", do_not_show_survey_for_legacy_base_paths_payload)
 
     visit("/done/transaction-finished")
     expect(page).to have_content(I18n.translate("controllers.contact.govuk.service_feedback.thanks_for_visiting"))


### PR DESCRIPTION
[Trello](https://trello.com/c/xNKiA1AU/622-respond-to-zendesk-ticket-fix-bug-in-feedback-csv-export-slug-is-incorrectly-formatted)

### What?

This PR fixes the formatting of the completed transaction slugs.

Previously the slug was sent through as 'done/transaction-name/'. This caused an issue which was raised in [this Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5395377). When exporting the data in Feedex, the end user expected to see the slug, for example 'transaction-name' as opposed 'done/transaction-name/', which is what they were seeing. This caused issues with their reporting.

The slug is now sent to the Support API in the correct format as a result of these changes.

### How does the end user see the data that is submitted here?

 done/transaction name data is send via the Feedback application to the Support API.

This data is then used when a user clicks the 'Export CSV' button in Feedex (the code for Feedex is in the Support application). [This is the export-csv code in Support](https://github.com/alphagov/support/blob/main/app/controllers/anonymous_feedback/export_requests_controller.rb#L10).

[The CSV is then generated in the Support API code](https://github.com/alphagov/support-api/blob/main/app/presenters/feedback_csv_row_presenter.rb#L32). We can see that it uses `row.slug` for `service-feedback`.


### Refactoring
 
It was realised that the naming in the completed_transaction code caused some confusion as there were places where what was actually the 'base_path' was referred to as the 'slug'. In reality we need the 'base_path' for rendering the form from the content item and we need the 'slug' to be passed through the form as a hidden field and onto the Support API. This naming issue is fixed in the second commit.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
