### PR TITLE
Remove giraffe field validation

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -11,7 +11,6 @@ class Ticket
   # 1 character long.
   FIELD_MAXIMUM_CHARACTER_COUNT = 1250
 
-  validate :validate_giraffe
   validates :url, length: { maximum: 2048 }
   validates :user_agent, length: { maximum: 2048 }
 
@@ -40,12 +39,5 @@ class Ticket
 
   def referrer
     UrlNormaliser.url_if_valid(@referrer)
-  end
-
-private
-
-  def validate_giraffe
-    # giraffe is used as a naive bot-preventor
-    @errors.add :giraffe if giraffe.present?
   end
 end

--- a/spec/models/report_a_problem_ticket_spec.rb
+++ b/spec/models/report_a_problem_ticket_spec.rb
@@ -35,14 +35,6 @@ RSpec.describe ReportAProblemTicket, type: :model do
     expect(ticket(what_doing: "").errors[:what_doing].size).to eq(1)
   end
 
-  it "should validate the absence of 'giraffe'" do
-    expect(ticket(giraffe: "").errors[:giraffe].size).to eq(0)
-  end
-
-  it "should invalidate the presence of 'giraffe' (suspected spam)" do
-    expect(ticket(giraffe: "Lorem ipsum dolor sit amet, consectetur adipiscing elit").errors[:giraffe].size).to eq(1)
-  end
-
   it "should filter 'javascript_enabled'" do
     expect(ticket(javascript_enabled: "true").javascript_enabled).to be_truthy
 

--- a/spec/models/ticket_spec.rb
+++ b/spec/models/ticket_spec.rb
@@ -4,12 +4,6 @@ RSpec.describe Ticket, type: :model do
   it { is_expected.to allow_value("https://www.gov.uk/done/whatever").for(:url) }
   it { is_expected.not_to be_spam }
 
-  context "a bot has populated the giraffe field" do
-    let(:subject) { Ticket.new(giraffe: "xxxxx") }
-    it { is_expected.to be_spam }
-    it { is_expected.not_to be_valid }
-  end
-
   it "should validate the length of URLs" do
     expect(Ticket.new(url: "https://www.gov.uk/#{'a' * 2048}").errors[:url].size).to eq(1)
   end


### PR DESCRIPTION
we removed the spam detection and it's preventing a form from being submitted

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
