### PR TITLE
Add Access-Control-Allow-Origin header to feedback responses

### DIFF
--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -5,6 +5,7 @@ class ContactController < ApplicationController
   include ApplicationHelper
 
   before_action :set_expiry, only: %i[new index]
+  after_action :add_cors_header
 
   def index
     @popular_links = filtered_links(CONTACT_LINKS.popular)
@@ -125,5 +126,12 @@ private
 
   def technical_attributes
     { user_agent: request.user_agent }
+  end
+
+  def add_cors_header
+    origin_header = request.headers["origin"]
+    if origin_header && origin_header.end_with?(".gov.uk")
+      response.headers["Access-Control-Allow-Origin"] = origin_header
+    end
   end
 end

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -204,6 +204,50 @@ RSpec.describe "Contact", type: :request do
     end
   end
 
+  it "should include the Access-Control-Allow-Origin if the request came from .gov.uk" do
+    stub_support_named_contact_creation
+
+    params = {
+      contact: {
+        query: "report-problem",
+        link: "www.test.com",
+        location: "specific",
+        name: "test name",
+        email: "test@test.com",
+        textdetails: "test text details",
+      },
+    }
+    headers = { "ORIGIN" => "https://assets.publishing.service.gov.uk" }
+    post("/contact/govuk", params:, headers:)
+
+    assert_requested(:post, %r{/named_contacts}) do |_request|
+      response.headers["Access-Control-Allow-Origin"] == "https://assets.publishing.service.gov.uk"
+    end
+  end
+
+  it "shouldn't include the Access-Control-Allow-Origin if the request did not come from .gov.uk" do
+    stub_support_named_contact_creation
+
+    params = {
+      contact: {
+        query: "report-problem",
+        link: "www.test.com",
+        location: "specific",
+        name: "test name",
+        email: "test@test.com",
+        textdetails: "test text details",
+      },
+    }
+
+    headers = { "ORIGIN" => "https://not-gov.uk" }
+
+    post("/contact/govuk", params:, headers:)
+
+    assert_requested(:post, %r{/named_contacts}) do |_request|
+      response.headers["Access-Control-Allow-Origin"].nil?
+    end
+  end
+
   it "should include the referrer if present in the contact params" do
     stub_support_named_contact_creation
 


### PR DESCRIPTION
## What

- We have the feedback form on domains that aren't `www.gov.uk`, such as integration, staging, and on production at `assets.publishing.service.gov.uk`. 
- The feedback form does not work properly on these other domain, because the `feedback` app rejects sending the response body if the request didn't come from `www.gov.uk`. Example of the form being broken on production is [here.](https://assets.publishing.service.gov.uk/media/6425aa8c60a35e00120cb279/List_of_gov.uk_domains_as_of_30_March_2023.csv/preview).
- The form still sends data on these other domains, i.e. it does actually send the feedback to the database, but the CORS error response makes the user see an error in the website UI, leading them to believe their feedback submission failed.
- Therefore, to fix this, we need to add the `Access-Control-Allow-Origin` response header. This is because the CORS error was `Access to XMLHttpRequest at 'https://www.gov.uk/contact/govuk/email-survey-signup' from origin 'https://assets.publishing.service.gov.uk/' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource`. So the fix is to add the header to the responses.
- This header only allows you to specify one domain at a time, or allow all domains on the web (by using an asterisk.) Therefore to allow multiple domains but restrict it to GOVUK only, in the rails controller we only send `Access-Control-Allow-Origin` if the domain ends in `.gov.uk`. This allows the header to work for integration, staging, and the assets domain, as it changes the header based on which GOVUK domain sent the request.

## Testing

I deployed this branch to integration, and the feedback form now shows the "Success" message to the user, and there's no CORS error in the console.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
