### PR TITLE
Fix locale enforcement on GA4 form tracking

### DIFF
--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -1,12 +1,12 @@
 <%
   ga4_english_strings = {
-    page_title: t("controllers.contact.govuk.contact_govuk.title", lang: :en),
+    page_title: t("controllers.contact.govuk.contact_govuk.title", locale: :en),
     questions: {
-      link: t("controllers.contact.govuk.contact_govuk.questions.link", lang: :en),
-      textdetails: t("controllers.contact.govuk.contact_govuk.questions.textdetails", lang: :en),
-      contact: t("controllers.contact.govuk.contact_govuk.questions.contact", lang: :en),
+      link: t("controllers.contact.govuk.contact_govuk.questions.link", locale: :en),
+      textdetails: t("controllers.contact.govuk.contact_govuk.questions.textdetails", locale: :en),
+      contact: t("controllers.contact.govuk.contact_govuk.questions.contact", locale: :en),
     },
-    submit_text: t("controllers.contact.govuk.contact_govuk.submit_text", lang: :en)
+    submit_text: t("controllers.contact.govuk.contact_govuk.submit_text", locale: :en)
   }
 
   ga4_form_tracker_json = {


### PR DESCRIPTION
## What 
- Change `lang: :en` to `locale: en` on GA4 contact form tracking
- Would add a test, but only the English version of the strings exist

## Why
- I used the wrong word (`lang` instead of `locale`)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
