### PR TITLE
Add GA4 section to GOVUK contact form_complete event

### DIFF
--- a/app/views/contact/govuk/anonymous_feedback_thankyou.html.erb
+++ b/app/views/contact/govuk/anonymous_feedback_thankyou.html.erb
@@ -2,6 +2,6 @@
 <% content_for :title, title %>
 <p class="govuk-body" 
    data-module="ga4-auto-tracker"
-   data-ga4-auto="<%= { event_name: "form_complete", type: "contact", text: title, action: "complete", tool_name: "Contact GOV.UK" }.to_json %>">
+   data-ga4-auto="<%= { event_name: "form_complete", type: "contact", text: title, action: "complete", tool_name: "Contact GOV.UK", section: title }.to_json %>">
   <a href="/" class="govuk-link">Return to the GOV.UK home page</a>.
 </p>

--- a/app/views/contact/govuk/named_contact_thankyou.html.erb
+++ b/app/views/contact/govuk/named_contact_thankyou.html.erb
@@ -1,6 +1,7 @@
-<% content_for :title, "Thank you for contacting GOV.UK" %>
+<% title = "Thank you for contacting GOV.UK" %>
+<% content_for :title, title %>
 <% success_message = "Your message has been sent, and the team will get back to you to answer any questions as soon as possible." %>
 
-<p class="govuk-body" data-module="ga4-auto-tracker" data-ga4-auto="<%= { event_name: "form_complete", type: "contact", text: success_message, action: "complete", tool_name: "Contact GOV.UK" }.to_json %>"><%= success_message %></p>
+<p class="govuk-body" data-module="ga4-auto-tracker" data-ga4-auto="<%= { event_name: "form_complete", type: "contact", text: success_message, action: "complete", tool_name: "Contact GOV.UK", section: title }.to_json %>"><%= success_message %></p>
 
 <p class="govuk-body"><a class="govuk-link" href="/">Return to the GOV.UK home page</a>.</p>

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -356,11 +356,14 @@ RSpec.describe "Contact", type: :request do
     ga4_auto_element = page.first("p[data-module=ga4-auto-tracker]")
     ga4_data = JSON.parse(ga4_auto_element["data-ga4-auto"])
 
+    title = "Thank you for contacting GOV.UK"
+
     expect(ga4_data["event_name"]).to eq "form_complete"
     expect(ga4_data["type"]).to eq "contact"
-    expect(ga4_data["text"]).to eq "Thank you for contacting GOV.UK"
+    expect(ga4_data["text"]).to eq title
     expect(ga4_data["action"]).to eq "complete"
     expect(ga4_data["tool_name"]).to eq "Contact GOV.UK"
+    expect(ga4_data["section"]).to eq title
 
     visit "/contact/govuk/thankyou"
 
@@ -374,6 +377,7 @@ RSpec.describe "Contact", type: :request do
     expect(ga4_data["text"]).to eq "Your message has been sent, and the team will get back to you to answer any questions as soon as possible."
     expect(ga4_data["action"]).to eq "complete"
     expect(ga4_data["tool_name"]).to eq "Contact GOV.UK"
+    expect(ga4_data["section"]).to eq title
   end
 
   it "should have the GA4 auto tracker on form error" do


### PR DESCRIPTION
## What

- Adds `section` value to `form_complete` events, containing the `h1` of the page

## Why

- The PAs missed it in the implementation guide 
- https://trello.com/c/Xnv0vnZR/796-add-section-value-to-formcomplete-events-on-contact-form

## Testing

- You can run `feedback` via `govuk-docker`. However you will need to modify `support-api` to use Ruby `3.2.3` instead of Ruby `3.3.0` as there is an issue with this version and Apple CPUs.
- The pages this change affects are http://feedback.dev.gov.uk/contact/govuk/thankyou and http://feedback.dev.gov.uk/contact/govuk/anonymous-feedback/thankyou

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
