### PR TITLE
Downcase 'Send message' text in GA4 data

### DIFF
--- a/app/views/contact/govuk/new.html.erb
+++ b/app/views/contact/govuk/new.html.erb
@@ -6,7 +6,7 @@
       textdetails: t("controllers.contact.govuk.contact_govuk.questions.textdetails", locale: :en),
       contact: t("controllers.contact.govuk.contact_govuk.questions.contact", locale: :en),
     },
-    submit_text: t("controllers.contact.govuk.contact_govuk.submit_text", locale: :en)
+    submit_text: t("controllers.contact.govuk.contact_govuk.submit_text", locale: :en).downcase
   }
 
   ga4_form_tracker_json = {

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe "Contact", type: :request do
     expect(ga4_data["event_name"]).to eq "form_response"
     expect(ga4_data["type"]).to eq "contact"
     expect(ga4_data["section"]).to eq "What's it to do with?"
-    expect(ga4_data["action"]).to eq "Send message"
+    expect(ga4_data["action"]).to eq "send message"
     expect(ga4_data["tool_name"]).to eq "Contact GOV.UK"
   end
 


### PR DESCRIPTION
## What
- Downcase `Send message` to `send message` in our GA4 data

## Why
- Request by PAs https://trello.com/c/NAfwibZK/804-lowercase-action-on-contact-form-response-send-message
