### PR TITLE
Fix character count component issue

### DIFF
--- a/app/views/assisted_digital_feedback/_assistance_received.html.erb
+++ b/app/views/assisted_digital_feedback/_assistance_received.html.erb
@@ -47,8 +47,8 @@
       id_prefix: locals[:id_prefix],
       hint: t("controllers.contact.govuk.assisted_digital_feedback.no_pii_hint"),
       error_message: @error_message_assistance_improvement_comments,
-      id: @error_id_assistance_improvement_comments,
       value: @value_assistance_improvement_comments
     },
+    id: @error_id_assistance_improvement_comments,
     maxlength: 1250
   } %>

--- a/app/views/assisted_digital_feedback/_assistance_received_other.html.erb
+++ b/app/views/assisted_digital_feedback/_assistance_received_other.html.erb
@@ -56,8 +56,8 @@
       id_prefix: locals[:id_prefix],
       hint: t("controllers.contact.govuk.assisted_digital_feedback.no_pii_hint"),
       error_message: @error_message_assistance_improvement_comments_other,
-      id: @error_id_assistance_improvement_comments_other,
       value: @value_assistance_improvement_comments_other
     },
+    id: @error_id_assistance_improvement_comments_other,
     maxlength: 1250
   } %>

--- a/app/views/assisted_digital_feedback/_assisted_digital_satisfaction_survey.html.erb
+++ b/app/views/assisted_digital_feedback/_assisted_digital_satisfaction_survey.html.erb
@@ -37,8 +37,8 @@
         name: "service_feedback[assistance_received_comments]",
         value: @value_assistance_received_comments,
         error_message: @error_message_assistance_received_comments,
-        id: @error_id_assistance_received_comments,
       },
+      id: @error_id_assistance_received_comments,
       maxlength: 1250
     } %>
 

--- a/app/views/shared/_service_improvement_comment.html.erb
+++ b/app/views/shared/_service_improvement_comment.html.erb
@@ -8,7 +8,7 @@
       hint: t("controllers.contact.govuk.service_feedback.no_pii_hint"),
       value: @value_improvement_comments,
       error_message: @error_message_improvement_comments,
-      id: @error_id_improvement_comments
     },
+    id: @error_id_improvement_comments,
     maxlength: 1250
   } %>


### PR DESCRIPTION
## What

Fix character count component issue where the remaining character count fails to update while typing.

Review URL(s):
- https://www.integration.publishing.service.gov.uk/done/waste-carrier-or-broker-registration
- https://www.integration.publishing.service.gov.uk/done/register-waste-exemption
- https://www.integration.publishing.service.gov.uk/done/register-flood-risk-exemption
- https://www.integration.publishing.service.gov.uk/done/vehicle-tax

## Why

The `id` property is being used incorrectly. See https://components.publishing.service.gov.uk/component-guide/character_count/with_id_for_textarea.