### PR TITLE
Add Bring ID to Vote Promo

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -42,6 +42,10 @@ cy:
           very_dissatisfied: Anfodlon iawn
           yes: Oes
         service_feedback:
+          bring_id_to_vote:
+            title:
+            description:
+            link_text:
           electric_vehicle:
             title: Hybu ceir trydan
             description: Cael gwybod faint o arian y gallwch ei arbed ar danwydd drwy newid i gerbyd trydan.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,10 @@ en:
           very_dissatisfied: Very dissatisfied
           yes: Yes
         service_feedback:
+          bring_id_to_vote:
+            title: Bring photo ID to vote
+            description: You will need to show photo ID when you vote in person in some UK elections or referendums.
+            link_text: Check which photo ID you’ll need to vote
           electric_vehicle:
             title: Electric car promotion
             description: Find out how much money you can save on fuel by switching to an electric vehicle.


### PR DESCRIPTION
## What

Add Bring ID to Vote promo to list of promos on completed transaction pages.

## Why

Request from content designers.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
