### PR TITLE
Named contacts snags

### DIFF
--- a/app/lib/support_ticket_creator.rb
+++ b/app/lib/support_ticket_creator.rb
@@ -1,5 +1,6 @@
 require "gds_zendesk/client"
 require "gds_zendesk/dummy_client"
+require "gds_zendesk/users"
 
 class SupportTicketCreator
   def self.call(...) = new(...).send
@@ -10,6 +11,7 @@ class SupportTicketCreator
   end
 
   def send
+    zendesk_client.users.search(query: @requester[:email])
     zendesk_client.tickets.create!(payload)
   end
 

--- a/app/models/contact_ticket.rb
+++ b/app/models/contact_ticket.rb
@@ -39,7 +39,7 @@ private
   def ticket_details
     details = {
       details: textdetails,
-      link:, # needed for the `support` app
+      link:, # needed for 'named contact' requests
       user_specified_url: link, # needed for the `support-api` app
       user_agent:,
       referrer:,

--- a/spec/controllers/contact/govuk_controller_spec.rb
+++ b/spec/controllers/contact/govuk_controller_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe Contact::GovukController, type: :controller do
   render_views
 
   let(:valid_params) do
+    zendesk_has_user(email: "test@test.com", suspended: false)
+
     {
       contact: {
         name: "Joe Bloggs",

--- a/spec/lib/support_ticket_creator_spec.rb
+++ b/spec/lib/support_ticket_creator_spec.rb
@@ -17,12 +17,16 @@ RSpec.describe SupportTicketCreator do
       javascript_enabled: true,
     }
   end
-  let(:support_ticket) { SupportTicketCreator.new(args) }
+  let(:support_ticket) do
+    zendesk_has_user(email: args[:requester][:email], suspended: false)
+    SupportTicketCreator.new(args)
+  end
 
   describe ".call" do
     it "sends input via instance" do
       self.valid_zendesk_credentials = ZENDESK_CREDENTIALS
       stub_zendesk_ticket_creation
+      zendesk_has_user(email: args[:requester][:email], suspended: false)
 
       expect { SupportTicketCreator.call(args) }.to_not raise_exception
     end
@@ -30,6 +34,7 @@ RSpec.describe SupportTicketCreator do
     it "ignores any extra keyword arguments" do
       self.valid_zendesk_credentials = ZENDESK_CREDENTIALS
       stub_zendesk_ticket_creation
+      zendesk_has_user(email: args[:requester][:email], suspended: false)
       messy_args = args.merge(foo: "bar")
 
       expect { SupportTicketCreator.call(messy_args) }.to_not raise_exception

--- a/spec/lib/support_ticket_creator_spec.rb
+++ b/spec/lib/support_ticket_creator_spec.rb
@@ -79,6 +79,11 @@ RSpec.describe SupportTicketCreator do
       expect(support_ticket.payload[:subject]).to eq("Named contact")
     end
 
+    it "includes dynamic subject if link provided" do
+      args[:link] = "https://www.gov.uk/browse/visas-immigration"
+      expect(support_ticket.payload[:subject]).to eq("Named contact about /browse/visas-immigration")
+    end
+
     it "includes hardcoded tags" do
       expect(support_ticket.payload[:tags]).to eq(%w[public_form named_contact])
     end

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should let the user submit a request with contact details" do
+    zendesk_has_user(email: "a@a.com", suspended: false)
     body = <<~MULTILINE_STRING
       [Requester]
       test name <a@a.com>
@@ -107,6 +108,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should not proceed if the user hasn't filled in all required fields" do
+    zendesk_has_user(email: "a@a.com", suspended: false)
     visit "/contact/govuk"
 
     choose "location-0" # Selects the 'The whole site' radio button
@@ -123,6 +125,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should not let the user submit a request with email without name" do
+    zendesk_has_user(email: "a@a.com", suspended: false)
     visit "/contact/govuk"
 
     choose "location-0" # Selects the 'The whole site' radio button
@@ -155,6 +158,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should let the user submit a request with a link" do
+    zendesk_has_user(email: "a@a.com", suspended: false)
     stub_zendesk_ticket_creation
 
     visit "/contact/govuk"
@@ -193,6 +197,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should include the user agent if available" do
+    zendesk_has_user(email: "test@test.com", suspended: false)
     stub_zendesk_ticket_creation
 
     # Using Rack::Test to allow setting the user agent.
@@ -215,6 +220,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should include the Access-Control-Allow-Origin if the request came from .gov.uk" do
+    zendesk_has_user(email: "test@test.com", suspended: false)
     stub_zendesk_ticket_creation
 
     params = {
@@ -236,6 +242,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "shouldn't include the Access-Control-Allow-Origin if the request did not come from .gov.uk" do
+    zendesk_has_user(email: "test@test.com", suspended: false)
     stub_zendesk_ticket_creation
 
     params = {
@@ -259,6 +266,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should include the referrer if present in the contact params" do
+    zendesk_has_user(email: "test@test.com", suspended: false)
     stub_zendesk_ticket_creation
 
     params = {
@@ -280,6 +288,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should include the referrer if present in the post" do
+    zendesk_has_user(email: "test@test.com", suspended: false)
     stub_zendesk_ticket_creation
 
     params = {
@@ -301,6 +310,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should include the referrer from the request" do
+    zendesk_has_user(email: "test@test.com", suspended: false)
     stub_zendesk_ticket_creation
 
     params = {
@@ -321,6 +331,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should have a cookie with the previous page page before filling the form", js: true do
+    zendesk_has_user(email: "a@a.com", suspended: false)
     visit "/contact"
     click_on "GOV.UK contact form"
 
@@ -340,6 +351,7 @@ RSpec.describe "Contact", type: :request do
   end
 
   it "should have the GA4 form tracker on the form" do
+    zendesk_has_user(email: "a@a.com", suspended: false)
     visit "/contact/govuk"
 
     expect(page).to have_selector(".contact-form[data-module=ga4-form-tracker]")

--- a/spec/requests/rate_limiting_spec.rb
+++ b/spec/requests/rate_limiting_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "Rack::Attack Throttling of POSTs", type: :request do
     Rack::Attack.enabled = true
     self.valid_zendesk_credentials = ZENDESK_CREDENTIALS
     stub_zendesk_ticket_creation
+    zendesk_has_user(email: "test@test.com", suspended: false)
+    zendesk_has_user(email: "test1@test.com", suspended: false)
+    zendesk_has_user(email: "test2@test.com", suspended: false)
+    zendesk_has_user(email: "test3@test.com", suspended: false)
+    zendesk_has_user(email: "new.email@test.com", suspended: false)
   end
 
   after do


### PR DESCRIPTION
This is a follow-up to #1835, addressing a couple of snags with the release:

1. Dynamic "subject" lines, based on the user-provided link, for feature parity with the Support app
2. Skipping over contact forms submitted by known 'suspended' users

Trello: https://trello.com/c/5MjV6r3T/3446-5-remove-feedbacks-dependency-on-support-app

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
