### PR TITLE
Move from Uglifier to Terser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "plek"
 gem "rack-attack"
 gem "slimmer"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 gem "valid_email"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -655,14 +655,14 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringio (3.1.0)
+    terser (1.2.2)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timeout (0.4.1)
     trailblazer-option (0.1.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9.1)
@@ -720,7 +720,7 @@ DEPENDENCIES
   simplecov
   slimmer
   sprockets-rails
-  uglifier
+  terser
   valid_email
   webmock
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
   config.serve_static_files = false
 
   # Compress JS using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Don't log any deprecations.
   config.active_support.report_deprecations = false


### PR DESCRIPTION
## What
Use Terser instead of Uglifier to compile JavaScript.

## Why
This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l), [Jira issue NAV-12307](https://gov-uk.atlassian.net/browse/NAV-12307)

## Further info

### JS Size

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer |  email-alert-frontend/application.js | 106KB | 19.5KB |
| terser |  email-alert-frontend/application.js | 106KB | 19.6KB |

### Browser testing

I've tested the changes on Integration using the browser below, functionality works as expected without any console errors.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11