### PR TITLE
Bump govuk_publishing_components from 38.3.0 to 38.3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (38.3.0)
+    govuk_publishing_components (38.3.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -365,7 +365,7 @@ GEM
       opentelemetry-api (~> 1.0)
       opentelemetry-common (~> 0.21.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
-    opentelemetry-instrumentation-grape (0.1.7)
+    opentelemetry-instrumentation-grape (0.1.8)
       opentelemetry-api (~> 1.0)
       opentelemetry-instrumentation-base (~> 0.22.1)
       opentelemetry-instrumentation-rack (~> 0.21)
@@ -538,7 +538,7 @@ GEM
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
-    reline (0.5.6)
+    reline (0.5.7)
       io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -683,7 +683,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.6.13)
+    zeitwerk (2.6.14)
     zendesk_api (3.0.5)
       faraday (> 2.0.0)
       faraday-multipart


### PR DESCRIPTION
# 38.3.1
- Remove Oxford comma from metadata component (https://github.com/alphagov/govuk_publishing_components/pull/4012)
- Add null check for input element (https://github.com/alphagov/govuk_publishing_components/pull/4022)