### PR TITLE
Upgrade to govuk frontend 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_directory ../javascripts .js
+//= link es6-components.js
 //= link_tree ../builds

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,8 +1,5 @@
 //= require govuk_publishing_components/lib
-//= require govuk_publishing_components/components/character-count
 //= require govuk_publishing_components/components/details
-//= require govuk_publishing_components/components/error-summary
-//= require govuk_publishing_components/components/radio
 //= require govuk_publishing_components/components/step-by-step-nav
 
 (function () {

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,12 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/radio

--- a/app/views/layouts/accessible_format_requests.html.erb
+++ b/app/views/layouts/accessible_format_requests.html.erb
@@ -22,5 +22,6 @@
 
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
     <%= javascript_include_tag 'application', integrity: false %>
+    <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,6 +29,7 @@
     <%= yield :body %>
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
     <%= javascript_include_tag 'application', integrity: false %>
+    <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>
 </html>
 

--- a/app/views/layouts/service_feedback.html.erb
+++ b/app/views/layouts/service_feedback.html.erb
@@ -36,5 +36,6 @@
     </div>
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
     <%= javascript_include_tag 'application', integrity: false %>
+    <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>
 </html>


### PR DESCRIPTION
## What

- Move components that rely on govuk-frontend modules to separate `es6-components.js` file

## Why

govuk_publishing_components uses v5 of govuk-frontend. There are several breaking changes in this release and so we need to update the applications that use govuk_publishing_components. Please read what has changed in [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/pull/3700) and [govuk-frontend](https://github.com/alphagov/govuk-frontend/releases/tag/v5.0.0-beta.0). This specific changes this PR addresses are:

- Move components that rely on govuk-frontend modules to seperate `es6-components.js` file
  * In the event that a browser below the target for `govuk-frontend` loads a page with JS on it, attempting to parse the JS from `govuk-frontend` will cause an error. To avoid this from happening, JS that contains `govuk-frontend` JS has been moved to seperate file which will be loaded in a script tag with `type="module"`. This will prevent the JS from being parsed and so prevent the error.

[Trello](https://trello.com/c/TrMW2Hdl/2516-upgrade-feedback-to-run-on-v51-of-govuk-frontend), [Jira issue NAV-12205](https://gov-uk.atlassian.net/browse/NAV-12205)

The intention is for the PR to include the upgrade to the version of the publishing_components_gem as well, once released.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.