### PR TITLE
Unpin ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby file: ".ruby-version"
+ruby "~> 3.3.1"
 
 gem "rails", "7.1.3.4"
 


### PR DESCRIPTION
The .ruby-version file specifies 3.3.1, but pulling this into the Gemfile pins this version exactly, which means we don't benefit from security fixes in later patch versions.

The bundler documentation suggests that patchlevel is optional for this exact reason - https://bundler.io/guides/gemfile_ruby.html - and supports the twiddle wakka syntax (~>) which here is equivalent to ">= 3.3.1", "< 3.4.0".

Sadly this means we have to go back to duplicating the version constraint in .ruby-version and the Gemfile, but c'est la vie.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
