### PR TITLE
Use type=module for application.js

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,7 +183,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/layouts/accessible_format_requests.html.erb
+++ b/app/views/layouts/accessible_format_requests.html.erb
@@ -21,7 +21,7 @@
     </div>
 
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
-    <%= javascript_include_tag 'application', integrity: false %>
+    <%= javascript_include_tag 'application', integrity: false, type: "module" %>
     <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
   <body>
     <%= yield :body %>
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
-    <%= javascript_include_tag 'application', integrity: false %>
+    <%= javascript_include_tag 'application', integrity: false, type: "module" %>
     <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>
 </html>

--- a/app/views/layouts/service_feedback.html.erb
+++ b/app/views/layouts/service_feedback.html.erb
@@ -34,7 +34,7 @@
         </div>
       </main>
     </div>
-    <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
+    <%= javascript_include_tag 'test-dependencies', type: "module" if Rails.env.test? %>
     <%= javascript_include_tag 'application', integrity: false, type: "module" %>
     <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>

--- a/app/views/layouts/service_feedback.html.erb
+++ b/app/views/layouts/service_feedback.html.erb
@@ -35,7 +35,7 @@
       </main>
     </div>
     <%= javascript_include_tag 'test-dependencies' if Rails.env.test? %>
-    <%= javascript_include_tag 'application', integrity: false %>
+    <%= javascript_include_tag 'application', integrity: false, type: "module" %>
     <%= javascript_include_tag 'es6-components.js', type: "module" %>
   </body>
 </html>


### PR DESCRIPTION
## What / Why
- Use type=module for this application's JS file
- To coincide with https://github.com/alphagov/govuk_publishing_components/pull/4111
- Has [DO NOT MERGE] as we want the above PR live on `static` first before this is merged.
- We will combine `es6-components.js` again as a separate task unless you disagree with this
- To accurately test this you will need to use local static that is using a local version the `govuk_publishing_components` branch linked above. If you test without, this app's `application.js` seems to crash.
- The tests are passing locally with the type=module branch of the gem, so the PR failing is likely due to the deployed version of the gem currently not having `type=module` as well.
- Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers, [Jira issue PNP-8523](https://gov-uk.atlassian.net/browse/PNP-8523)
