### PR TITLE
Update/add component print styles

### DIFF
--- a/app/views/shared/_promo.html.erb
+++ b/app/views/shared/_promo.html.erb
@@ -1,4 +1,4 @@
-<div class="promotion">
+<div class="promotion govuk-!-display-none-print">
   <%= render "govuk_publishing_components/components/heading", {
     text: title,
     font_size: "s",


### PR DESCRIPTION
## What
Hide the `promotion` element when printing "transaction done" pages. [Trello card](https://trello.com/c/PnEVIZtq/192-review-and-fix-application-component-print-styles), [Jira issue PNP-8589](https://gov-uk.atlassian.net/browse/PNP-8589)

Example page: https://www.gov.uk/done/transaction-finished

## Why
This change hides the grey promotion element when printed as it's redundant in a print context: the important part of that promotion is the link, which is pointless on a printout. 

NOTE: There's also an argument for hiding the Related Content as that's redundant when printed too, however this has not been changed as it might have cascading consequences for other pages.

## SCREEN (BEFORE)

![image](https://github.com/user-attachments/assets/b5191212-257d-4220-bbad-ed00bc221f7b)

## PRINT (AFTER)

![image](https://github.com/user-attachments/assets/51b2ddab-85d8-4dfd-94dc-70d0872cde71)