### PR TITLE
Handle when Support API returns a suspended user error

### DIFF
--- a/app/lib/support_ticket_creator.rb
+++ b/app/lib/support_ticket_creator.rb
@@ -11,6 +11,12 @@ class SupportTicketCreator
 
   def send
     GdsApi.support_api.raise_support_ticket(payload)
+  rescue GdsApi::HTTPUnprocessableEntity => e
+    if e.error_details.dig("errors", "requester")&.include?("is suspended in Zendesk")
+      Rails.logger.info("Support API skipped ticket creation because user is suspended")
+    else
+      raise e
+    end
   end
 
   def payload


### PR DESCRIPTION

When Support API detects the user is suspended in zendesk, it doesn't create a ticket and returns a 422 with a specific error message. Silently log those specific errors and return as though a ticket has been created (this replicates Feedback's original behaviour)

https://trello.com/c/1My5X2gE/313-handle-unprocessableentity-errors-in-feedback, [Jira issue PNP-8552](https://gov-uk.atlassian.net/browse/PNP-8552)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

