### PR TITLE
[GOVUKAPP-989] Add throttle decrementing

### DIFF
--- a/app/controllers/concerns/throttling_manager.rb
+++ b/app/controllers/concerns/throttling_manager.rb
@@ -1,0 +1,28 @@
+module ThrottlingManager
+  extend ActiveSupport::Concern
+
+  included do
+    def decrement_throttle_counts
+      if request.env["rack.attack.throttle_data"]
+        request.env["rack.attack.throttle_data"].each do |name, values|
+          decrement_throttle_count(name, values[:discriminator])
+        end
+      end
+    end
+  end
+
+private
+
+  def decrement_throttle_count(throttle_name, discriminator)
+    last_epoch_time = Time.zone.now.to_i
+    period = Rack::Attack.configuration.throttles[throttle_name].period
+    key_name = [
+      "rack::attack",
+      (last_epoch_time / period).to_i,
+      throttle_name,
+      discriminator,
+    ].join(":")
+
+    Rack::Attack.cache.store.decrement(key_name, 1)
+  end
+end

--- a/app/controllers/contact/govuk_app/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk_app/problem_reports_controller.rb
@@ -1,4 +1,6 @@
 class Contact::GovukApp::ProblemReportsController < ApplicationController
+  include ThrottlingManager
+
   def new
     @phone = params[:phone]
     @app_version = params[:app_version]
@@ -11,6 +13,8 @@ class Contact::GovukApp::ProblemReportsController < ApplicationController
       ticket.save
       redirect_to contact_govuk_app_confirmation_path
     else
+      decrement_throttle_counts
+
       @errors = ticket.errors.messages
       @ticket = ticket
       render "new"

--- a/app/controllers/contact/govuk_app/suggestions_controller.rb
+++ b/app/controllers/contact/govuk_app/suggestions_controller.rb
@@ -1,4 +1,6 @@
 class Contact::GovukApp::SuggestionsController < ApplicationController
+  include ThrottlingManager
+
   def new; end
 
   def create
@@ -8,6 +10,8 @@ class Contact::GovukApp::SuggestionsController < ApplicationController
       ticket.save
       redirect_to contact_govuk_app_confirmation_path
     else
+      decrement_throttle_counts
+
       @errors = ticket.errors.messages
       @ticket = ticket
       render "new"

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -3,6 +3,7 @@ require "slimmer/headers"
 class ContactController < ApplicationController
   include Slimmer::Headers
   include ApplicationHelper
+  include ThrottlingManager
 
   before_action :set_expiry, only: %i[new index]
   after_action :add_cors_header
@@ -36,6 +37,8 @@ class ContactController < ApplicationController
       respond_to_valid_submission(ticket)
     else
       raise SpamError if ticket.spam?
+
+      decrement_throttle_counts
 
       @errors = ticket.errors.to_hash
       @old = data

--- a/spec/controllers/concerns/throttling_manager_spec.rb
+++ b/spec/controllers/concerns/throttling_manager_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ThrottlingManager do
+  let(:controller) { ThrottlingTestController.new }
+  let(:ip) { "192.168.1.1" }
+  let(:period) { 60 }
+  let(:key_name) do
+    "requests by ip:#{ip}"
+  end
+  let(:cache) { Rack::Attack.cache }
+
+  before do
+    cache.write(key_name, 1, period)
+
+    env = {
+      "rack.attack.throttle_data" => {
+        "requests by ip" => {
+          discriminator: ip,
+          count: 1,
+          period: period,
+          limit: 1,
+          epoch_time: Time.zone.now.to_i,
+        },
+      },
+    }
+
+    allow(controller).to receive(:request) { ActionDispatch::Request.new(env) }
+  end
+
+  it "decrements rack::attack throttle count" do
+    expect(cache.read(key_name)).to eq(1)
+
+    controller.decrement_throttle_counts
+
+    expect(cache.count(key_name, period)).to eq(0)
+  end
+end
+
+class ThrottlingTestController < ApplicationController
+  include ThrottlingManager
+end

--- a/spec/requests/govuk_app/problem_reports_spec.rb
+++ b/spec/requests/govuk_app/problem_reports_spec.rb
@@ -71,5 +71,15 @@ RSpec.describe "GOV.UK app problem reports", type: :request do
       expect(request).to_not have_been_made
       expect(response).to render_template("new")
     end
+
+    it "shouldn't rate limit submissions if there are form errors" do
+      params[:what_happened] = ""
+      post "/contact/govuk-app/report-problem", params: { problem_report: params }
+      expect(response.status).to eq(200)
+      3.times do
+        post "/contact/govuk-app/report-problem", params: { problem_report: params }
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end

--- a/spec/requests/govuk_app/suggestions_spec.rb
+++ b/spec/requests/govuk_app/suggestions_spec.rb
@@ -59,5 +59,15 @@ RSpec.describe "GOV.UK app suggestions", type: :request do
       expect(request).to_not have_been_made
       expect(response).to render_template("new")
     end
+
+    it "shouldn't rate limit submissions if there are form errors" do
+      params[:details] = ""
+      post "/contact/govuk-app/make-suggestion", params: { suggestion: params }
+      expect(response.status).to eq(200)
+      3.times do
+        post "/contact/govuk-app/make-suggestion", params: { suggestion: params }
+        expect(response.status).to eq(200)
+      end
+    end
   end
 end


### PR DESCRIPTION
We don't want to throttle requests when validation errors occur, only when support tickets are actually submitted. This commits adds the ability to decrement the throttle count of the throttles we've configured.

I've added the config for both app forms and the main gov.uk technical support form as this seems highest impact (other controllers subclass ContactController but overwrite the create action). Other forms may want to follow suit.

The test for web gov.uk technical problem form is already covered in the rate_limiting_spec.rb so have skipped the spec in the contacts request spec.

Jira: https://govukverify.atlassian.net/jira/software/c/projects/GOVUKAPP/boards/559?selectedIssue=GOVUKAPP-989&useStoredSettings=true

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
