### PR TITLE
[GOVUKAPP-990] Autopopulate phone details

### DIFF
--- a/app/controllers/contact/govuk_app/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk_app/problem_reports_controller.rb
@@ -1,5 +1,8 @@
 class Contact::GovukApp::ProblemReportsController < ApplicationController
-  def new; end
+  def new
+    @phone = params[:phone]
+    @app_version = params[:app_version]
+  end
 
   def create
     ticket = AppProblemReportTicket.new(problem_report_params)

--- a/app/controllers/contact/govuk_app_controller.rb
+++ b/app/controllers/contact/govuk_app_controller.rb
@@ -7,13 +7,18 @@ class Contact::GovukAppController < ApplicationController
     end
 
     if type == "problem"
-      redirect_to contact_govuk_app_report_problem_path
+      redirect_to contact_govuk_app_report_problem_path(params: phone_details_params)
     else
       redirect_to contact_govuk_app_make_suggestion_path
     end
   end
 
   def confirmation; end
+
+  helper_method :phone_details_params
+  def phone_details_params
+    params.slice(:phone, :app_version).permit!
+  end
 
 private
 

--- a/app/views/contact/govuk_app/confirmation.html.erb
+++ b/app/views/contact/govuk_app/confirmation.html.erb
@@ -2,6 +2,4 @@
   title: t("controllers.contact.govuk_app.confirmation.message")
 } %>
 
-<p class="govuk-body">Thank you for your message.</p>
-<p class="govuk-body">We'll respond to you in 2 working days.</p>
-<p class="govuk-body"><a href="https://www.gov.uk">Return to the GOV.UK homepage</a></p>
+<%= t("controllers.contact.govuk_app.confirmation.thanks_html") %>

--- a/app/views/contact/govuk_app/new.html.erb
+++ b/app/views/contact/govuk_app/new.html.erb
@@ -33,7 +33,7 @@
   end
 end %>
 
-<%= form_tag contact_govuk_app_path, method: :post, class: "contact-form", data: { module: "ga4-form-tracker", ga4_form: ga4_form_tracker_json } do |f| %>
+<%= form_tag contact_govuk_app_path(params: phone_details_params), method: :post, class: "contact-form", data: { module: "ga4-form-tracker", ga4_form: ga4_form_tracker_json } do |f| %>
   <% content_for :title do t("controllers.contact.govuk_app.new.title") end %>
   <%= t("controllers.contact.govuk_app.new.description_html") %>
 

--- a/app/views/contact/govuk_app/problem_reports/new.html.erb
+++ b/app/views/contact/govuk_app/problem_reports/new.html.erb
@@ -55,7 +55,7 @@ end %>
     },
     name: "problem_report[phone]",
     id: "phone",
-    value: @ticket ? @ticket.phone : nil,
+    value: @ticket ? @ticket.phone : @phone,
     width: 20
   } %>
 
@@ -66,7 +66,7 @@ end %>
     },
     name: "problem_report[app_version]",
     id: "app_version",
-    value: @ticket ? @ticket.app_version : nil,
+    value: @ticket ? @ticket.app_version : @app_version,
     width: 20
   } %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,10 +31,13 @@ en:
           description_html: |
             <p class="govuk-body">You can use this form to report a problem with the app or make a suggestion for improving the app.</p>
             <p class="govuk-body">We can’t reply to you with advice. We don’t have access to information about you held by government departments.</p>
-            <p class="govuk-body">If you have a question about a government service or policy, <a class="govuk-link" href="/help">find contact details for the service</a> or contact the <a class="govuk-link" href="/government/organisations">government department</a> directly.</p>
+            <p class="govuk-body">If you have a question about a government service or policy, <a class="govuk-link" href="/contact">find contact details for the service</a> or contact the <a class="govuk-link" href="/government/organisations">government department</a> directly.</p>
           contact_type_error_message: Select if you want to report a problem or make a suggestion
         confirmation:
           message: Your message has been submitted
+          thanks_html: |
+            <p class="govuk-body">Thank you for your message.</p>
+            <p class="govuk-body"><a href="https://www.gov.uk">Return to the GOV.UK homepage</a></p>
         problem_reports:
           new:
             title: Report a problem with the GOV.UK app

--- a/spec/requests/govuk_app_spec.rb
+++ b/spec/requests/govuk_app_spec.rb
@@ -3,14 +3,18 @@ require "rails_helper"
 RSpec.describe "GOV.UK App", type: :request do
   context "#new" do
     it "should display new page" do
-      visit "/contact/govuk-app"
+      visit "/contact/govuk-app?phone=Apple+iPhone&app_version=1.0"
       expect(page).to have_title "Contact the GOV.UK app team"
     end
   end
 
   context "#create" do
     it "should redirect to problem report form given problem type" do
-      post "/contact/govuk-app", params: { contact: { type: "problem" } }
+      post "/contact/govuk-app", params: {
+        contact: { type: "problem" },
+        phone: "Apple+iPhone&app_version=1.0",
+        app_version: "1.0",
+      }
 
       follow_redirect!
 
@@ -20,7 +24,11 @@ RSpec.describe "GOV.UK App", type: :request do
     end
 
     it "should render suggestions form given suggestion type" do
-      post "/contact/govuk-app", params: { contact: { type: "suggestion" } }
+      post "/contact/govuk-app", params: {
+        contact: { type: "suggestion" },
+        phone: "Apple+iPhone&app_version=1.0",
+        app_version: "1.0",
+      }
 
       follow_redirect!
 

--- a/spec/system/app_problem_report_spec.rb
+++ b/spec/system/app_problem_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Submitting app problem report" do
 
   context "when selecting report a problem" do
     before do
-      visit "/contact/govuk-app"
+      visit "/contact/govuk-app?app_version=1.0&phone=Apple+iPhone+15+pro+18.1"
       choose("Report a problem with the app")
       click_on("Continue")
     end
@@ -40,12 +40,20 @@ RSpec.describe "Submitting app problem report" do
       expect(page).to have_title("Report a problem with the GOV.UK app")
     end
 
-    it "includes phone model field" do
+    it "includes phone field" do
       expect(page).to have_field("What phone do you have?")
+    end
+
+    it "populates phone field with phone query param" do
+      expect(page.find("#phone").value).to eq("Apple iPhone 15 pro 18.1")
     end
 
     it "includes app version field" do
       expect(page).to have_field("The app version where you found the problem")
+    end
+
+    it "populates app version field with app_version query param" do
+      expect(page.find("#app_version").value).to eq("1.0")
     end
 
     it "includes what you were trying to do field" do


### PR DESCRIPTION
Accepts app_version & phone as query params. Both Android and iOS apps
will send this information over when a user clicks the link from the respective apps.

Jira: https://govukverify.atlassian.net/jira/software/c/projects/GOVUKAPP/boards/559?selectedIssue=GOVUKAPP-990&useStoredSettings=true

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
