### PR TITLE
Use heading component instead of title

### DIFF
--- a/app/views/layouts/service_feedback.html.erb
+++ b/app/views/layouts/service_feedback.html.erb
@@ -15,7 +15,12 @@
       <main class="govuk-main-wrapper" id="content" role="main" <%= @lang_attribute %>>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-two-thirds">
-            <%= render 'govuk_publishing_components/components/title', margin_top: 0, title: yield(:title) %>
+            <%= render 'govuk_publishing_components/components/heading', {
+              text: yield(:title),
+              heading_level: 1,
+              font_size: "xl",
+              margin_bottom: 8,
+            } %>
           </div>
           <div class="govuk-grid-column-two-thirds">
             <%= yield %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Use the heading component in place of the title component on pages such as https://www.gov.uk/done/register-flood-risk-exemption

## Why

- the title component uses margin_top: 0 but this option is being removed from the component
- instead, use the heading component, which in this case can be configured to look exactly the same

## Visual changes
None.

Trello card: https://trello.com/c/Y0pDWbHw/390-move-some-shared-helper-options-into-component-wrapper, [Jira issue PNP-7399](https://gov-uk.atlassian.net/browse/PNP-7399)


