### PR TITLE
Use equal item spacing on gem document-lists on Contact

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title do "Find contact details for services" end %>
   <%= render "govuk_publishing_components/components/document_list", {
+    equal_item_spacing: true,
     items: @popular_links
   } %>
 
@@ -7,6 +8,7 @@
     title: "More topics"
   } do %>
     <%= render "govuk_publishing_components/components/document_list", {
+      equal_item_spacing: true,
       items: @long_tail_links
     } %>
   <% end %>


### PR DESCRIPTION
, [Jira issue NAV-15226](https://gov-uk.atlassian.net/browse/NAV-15226)## What
Use equal item spacing on the document-list on /contact. 

## Why
This requirement came out of a design review of the spacing on the lists on /contact and /help, relating to [this Trello card](https://trello.com/c/F3iYypdh).

## Further detail
We'll also check the if [the documentation for the equal-item-spacing option](https://components.publishing.service.gov.uk/component-guide/document_list/with_equal_item_spacing) needs to change to reflect that it's now being used in places other than the new search UI. 

## Screenshots

### Before
<img width="812" alt="Screenshot 2025-01-07 at 17 03 48" src="https://github.com/user-attachments/assets/89822883-f3ee-4822-95a2-b792e50ff3b8" />

### After
<img width="809" alt="Screenshot 2025-01-07 at 17 03 32" src="https://github.com/user-attachments/assets/1ad23bcb-0dcf-4d44-8f1f-136247593af2" />

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
