### PR TITLE
Replace title component with heading and match visual style

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,11 +4,16 @@
       breadcrumbs: @breadcrumbs,
       collapse_on_mobile: true
     } %>
-    <main id="content" role="main">
+    <main id="content" role="main" class="govuk-main-wrapper--l">
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <%= yield(:error_summary) %>
-          <%= render 'govuk_publishing_components/components/title', title: yield(:title) %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: yield(:title),
+            heading_level: 1,
+            font_size: "xl",
+            margin_bottom: 8
+          } %>
           <%= yield %>
         </div>
       </div>


### PR DESCRIPTION
## What
Replace title components with headings.

## Why
We are attempting to retire the page title component in favour of the heading component. [Trello](https://trello.com/c/5BQ7SJ7h/446-replace-title-with-heading-in-feedback), [Jira issue PNP-9261](https://gov-uk.atlassian.net/browse/PNP-9261)

## Visual Changes
A minor change to spacing on mobile:
![image](https://github.com/user-attachments/assets/b9d08777-0acd-4e2c-8232-46d2a7e05403)

No changes on desktop view
![image](https://github.com/user-attachments/assets/df7fbc64-12db-4128-8f51-4f236558f9e2)
