### PR TITLE
Only fire the GA4 auto tracker if the originating form is /contact/govuk

### DIFF
--- a/app/controllers/contact/govuk_controller.rb
+++ b/app/controllers/contact/govuk_controller.rb
@@ -5,12 +5,17 @@ class Contact::GovukController < ContactController
     hide_report_a_problem_form_in_response
   },
                 only: %i[anonymous_feedback_thankyou named_contact_thankyou]
+  before_action :check_govuk_contact_form
 
   def anonymous_feedback_thankyou; end
 
   def named_contact_thankyou; end
 
 private
+
+  def check_govuk_contact_form
+    @govuk_contact_form = params[:govuk_contact_form] == "true"
+  end
 
   def ticket_class
     ContactTicket

--- a/app/controllers/contact_controller.rb
+++ b/app/controllers/contact_controller.rb
@@ -89,10 +89,14 @@ private
     respond_to do |format|
       format.html do
         hide_report_a_problem_form_in_response
+        params = {}
+        if contact_params["url"] == Plek.new.website_root + contact_govuk_path
+          params[:govuk_contact_form] = true
+        end
         if @contact_provided
-          redirect_to contact_named_contact_thankyou_path
+          redirect_to contact_named_contact_thankyou_path(params)
         else
-          redirect_to contact_anonymous_feedback_thankyou_path
+          redirect_to contact_anonymous_feedback_thankyou_path(params)
         end
       end
       format.any { head(:not_acceptable) }

--- a/app/views/contact/govuk/anonymous_feedback_thankyou.html.erb
+++ b/app/views/contact/govuk/anonymous_feedback_thankyou.html.erb
@@ -1,7 +1,19 @@
-<% title = "Thank you for contacting GOV.UK" %>
-<% content_for :title, title %>
-<p class="govuk-body" 
-   data-module="ga4-auto-tracker"
-   data-ga4-auto="<%= { event_name: "form_complete", type: "contact", text: title, action: "complete", tool_name: "Contact GOV.UK", section: title }.to_json %>">
+<%
+  title = "Thank you for contacting GOV.UK"
+  content_for :title, title
+  data_attributes = {
+    module: "ga4-auto-tracker",
+    ga4_auto: {
+      event_name: "form_complete",
+      type: "contact",
+      text: title,
+      action: "complete",
+      tool_name: "Contact GOV.UK",
+      section: title,
+    }.to_json
+  } if @govuk_contact_form
+%>
+
+<%= tag.p(class: "govuk-body", data: data_attributes) do %>
   <a href="/" class="govuk-link">Return to the GOV.UK home page</a>.
-</p>
+<% end %>

--- a/app/views/contact/govuk/named_contact_thankyou.html.erb
+++ b/app/views/contact/govuk/named_contact_thankyou.html.erb
@@ -1,7 +1,25 @@
-<% title = "Thank you for contacting GOV.UK" %>
-<% content_for :title, title %>
-<% success_message = "Your message has been sent, and the team will get back to you to answer any questions as soon as possible." %>
+<%
+  title = "Thank you for contacting GOV.UK"
+  content_for :title, title
+  success_message = "Your message has been sent, and the team will get back to you to answer any questions as soon as possible."
 
-<p class="govuk-body" data-module="ga4-auto-tracker" data-ga4-auto="<%= { event_name: "form_complete", type: "contact", text: success_message, action: "complete", tool_name: "Contact GOV.UK", section: title }.to_json %>"><%= success_message %></p>
+  data_attributes = {
+    module: "ga4-auto-tracker",
+    ga4_auto: {
+      event_name: "form_complete",
+      type: "contact",
+      text: success_message,
+      action: "complete",
+      tool_name: "Contact GOV.UK",
+      section: title
+    }.to_json
+  } if @govuk_contact_form
+%>
 
-<p class="govuk-body"><a class="govuk-link" href="/">Return to the GOV.UK home page</a>.</p>
+<%= tag.p(class: "govuk-body", data: data_attributes) do %>
+  <%= success_message %>
+<% end %>
+
+<p class="govuk-body">
+  <a class="govuk-link" href="/">Return to the GOV.UK home page</a>.
+</p>

--- a/spec/requests/service_feedback_spec.rb
+++ b/spec/requests/service_feedback_spec.rb
@@ -67,6 +67,21 @@ RSpec.describe "Service feedback submission", type: :request do
       expect(page).to have_content "Thank you for contacting GOV.UK"
     end
 
+    it "does not have GA4 auto tracking on the thank you page" do
+      stub_content_store_has_item("/#{base_path}", payload)
+      visit("/done/some-transaction")
+      within(".service-feedback") do
+        choose I18n.translate("controllers.contact.govuk.service_feedback.very_satisfied")
+        fill_in I18n.translate("controllers.contact.govuk.service_feedback.how_improve"), with: "Test"
+        click_on I18n.translate("controllers.contact.govuk.service_feedback.send_feedback")
+      end
+
+      i_should_be_on "/contact/govuk/anonymous-feedback/thankyou"
+      expect(page).to have_content "Thank you for contacting GOV.UK"
+      expect(page).to_not have_selector("p[data-module=ga4-auto-tracker]")
+      expect(page).to_not have_selector("p[data-ga4-auto]")
+    end
+
     it "displays validation error when Service Satisfaction Rating is blank" do
       stub_content_store_has_item("/#{base_path}", payload)
       visit("/done/some-transaction")


### PR DESCRIPTION
## What / Why

- Multiple forms on GOVUK end up on the same `Thank you` view when the form is submitted. http://www.gov.uk/contact/govuk/thankyou
- Currently, our performance analysts are only interested in tracking the `Thank you` page when the origin is the GOVUK contact form (https://www.gov.uk/contact/govuk). 
- Therefore, I've added some logic to prevent other forms like service feedback forms from triggering the GA4 tracking. For example we don't want https://www.gov.uk/done/vehicle-log-book to trigger the Thank you page tracking.
- Trello card: https://trello.com/c/ndcXrOUL/

## How to test
1. Visit http://feedback.dev.gov.uk/contact/govuk/
2. Submit an anonymous form (Leave the name / email address blank)
3. On the 'Thank You' page, the paragraph will have `data-ga4-auto`.
4. Submit the form again, but this time with a name / email address.
5. You'll get a different version of the 'Thank You' page, and the paragraph should still have `data-ga4-auto`
6. Visit http://feedback.dev.gov.uk/contact/govuk/ again
7. Using `Inspect Element` edit the `contact_url` hidden input field so that the `value` is a service feedback page instead. You can use this HTML: `<input type="hidden" name="contact[url]" id="contact_url" value="http://www.gov.uk/done/vehicle-log-book" autocomplete="off">` 
8. On the thank you page, there will not be any GA4 tracking on the 'Thank you' paragraph, as that `url` form value was not `/contact/govuk/`

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
