### PR TITLE
Pass GA4 index_section_count to details component

### DIFF
--- a/app/views/contact/index.html.erb
+++ b/app/views/contact/index.html.erb
@@ -5,7 +5,8 @@
   } %>
 
   <%= render "govuk_publishing_components/components/details", {
-    title: "More topics"
+    title: "More topics",
+    ga4_attributes: { index_section_count: 1 }
   } do %>
     <%= render "govuk_publishing_components/components/document_list", {
       equal_item_spacing: true,

--- a/spec/requests/contact_spec.rb
+++ b/spec/requests/contact_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe "Contact", type: :request do
     expect(page).to have_title "Find contact details for services - GOV.UK"
   end
 
+  it "should pass index_section_count to the details component on the index page" do
+    visit "/contact"
+
+    details = page.first(".gem-c-details")
+    ga4_data = JSON.parse(details["data-ga4-event"])
+    expect(ga4_data["index_section_count"]).to eq 1
+  end
+
   it "should let the user submit a request with contact details" do
     body = <<~MULTILINE_STRING
       [Requester]


### PR DESCRIPTION
## What / Why
- Pass a GA4 value, `index_section_count: 1`, to the `details` component render
- As requested by our Performance Analysts: https://trello.com/c/2nhQfMwl/848-fix-details-missing-indexsectioncount-across-various-formats
- This `details` component is rendered towards the bottom of the `/contact` route.  https://feedback-pr-2080.herokuapp.com/contact
