### PR TITLE
Add meta tags for GA4 tracking

### DIFF
--- a/app/views/layouts/service_feedback.html.erb
+++ b/app/views/layouts/service_feedback.html.erb
@@ -3,6 +3,8 @@
   <head>
     <meta name="robots" content="noindex">
     <meta charset="utf-8" />
+    <meta name="govuk:format" content="<%= content_item_hash["document_type"] %>">
+    <meta name="govuk:schema-name" content="<%= content_item_hash["schema_name"] %>">
     <title><%= yield :title %> - GOV.UK</title>
     <%=
       render_component_stylesheets


### PR DESCRIPTION
The `/done` routes are missing meta tags, which are sent to Google Analytics. For example https://www.gov.uk/done/vehicle-log-book

This introduces a couple of those meta tags onto the page. Our JS will automatically grab these meta tag values and push them up to Google Analytics.

Test link: https://feedback-pr-2148.herokuapp.com/done/vehicle-log-book

Trello card: https://trello.com/c/HGQbzjIB/453-missing-documenttype-values-on-completedtransaction-pages

On a separate note, none of the layouts in this app seem to have our standard meta tags. Should an issue be opened to fix this? One benefit I can think of is the GA4 analytics will be more detailed - though the performance analysts have only asked for the two meta tags I've added in this PR.