### PR TITLE
[PNP-9913] pin dalli to 4 x in feedback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "rails", "8.1.3"
 
 gem "bootsnap", require: false
 gem "connection_pool", "< 3" # Do not bump via Dependabot - https://github.com/alphagov/feedback/pull/2319
-gem "dalli"
+gem "dalli", "~> 4"
 gem "dartsass-rails"
 gem "dotenv-rails"
 gem "gds-api-adapters"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
-    dalli (5.0.2)
+    dalli (4.3.3)
       logger
     dartsass-rails (0.5.1)
       railties (>= 6.0.0)
@@ -699,7 +699,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   connection_pool (< 3)
-  dalli
+  dalli (~> 4)
   dartsass-rails
   dotenv-rails
   gds-api-adapters

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 Rails.application.routes.draw do
+  checks = [
+    ENV["PLEK_HOSTNAME_PREFIX"] == "draft-" ? nil : GovukHealthcheck::RailsCache,
+  ].compact
+
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
-  get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(*checks)
 
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 


### PR DESCRIPTION
Pin Dalli to 4.x until we can upgrade memcached to 1.6.22 to prevent silent cache failures

Add RailsCache healthcheck when not in draft stack.

JIRA Card: https://gov-uk.atlassian.net/browse/PNP-9913

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
