### PR TITLE
Update colours to Design System v6

### DIFF
--- a/app/assets/stylesheets/views/_completed_transaction.scss
+++ b/app/assets/stylesheets/views/_completed_transaction.scss
@@ -1,6 +1,6 @@
 @import "govuk_publishing_components/base";
 
 .promotion {
-  background: govuk-colour("light-grey");
+  background: govuk-colour("black", $variant: "tint-95");
   padding: govuk-spacing(3);
 }


### PR DESCRIPTION
## What
Prepare for the update to Design System v6.0.0 by updating colours that were deprecated or replaced in that release.


This PR addresses the changes under "Use GOV.UK brand colours" in the [GOV.UK Frontend v6.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v6.0.0).

## Why
Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?quickFilter=2319&selectedIssue=NAV-1892
