### PR TITLE
Setup vs code debugging

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "terser"
 gem "valid_email"
 
 group :development, :test do
+  gem "debug"
   gem "govuk_schemas"
   gem "govuk_test"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,6 +111,9 @@ GEM
       railties (>= 6.0.0)
       sass-embedded (~> 1.63)
     date (3.5.1)
+    debug (1.11.1)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.6.2)
     docile (1.4.0)
     domain_name (0.6.20240107)
@@ -653,6 +656,7 @@ DEPENDENCIES
   csv
   dalli (~> 4)
   dartsass-rails
+  debug
   dotenv-rails
   gds-api-adapters
   govuk_app_config (= 9.25.1)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ You can use the [GOV.UK Docker environment](https://github.com/alphagov/govuk-do
 ```
 bundle exec rake
 ```
+### Debugging support
+
+See [Debugging](docs/debugging-in-vs-code.md)
 
 ## Further documentation
 

--- a/config/initializers/debug.rb
+++ b/config/initializers/debug.rb
@@ -1,0 +1,6 @@
+if Rails.env.development? && ENV["VIRTUAL_HOST"]
+  require "debug/session"
+  Rails.logger.info "Starting debug session"
+  # the port can be anything
+  DEBUGGER__.open(port: "12345", host: "0.0.0.0")
+end

--- a/docs/debugging-in-vs-code.md
+++ b/docs/debugging-in-vs-code.md
@@ -1,0 +1,25 @@
+# Debugging in VS Code
+
+If you want to debug within VS Code, you'll need the [VSCode rdbg Ruby Debugger](https://marketplace.visualstudio.com/items?itemName=KoichiSasada.vscode-rdbg) extension, and once that's installed, create a configuration file for it at `.vscode/launch.json` containing the following values
+
+```
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "rdbg",
+      "name": "Attach with rdbg",
+      "request": "attach",
+      "debugPort": "feedback.dev.gov.uk:12348",
+      "localfsMap": "/:${userHome}"
+    }
+  ]
+}
+```
+
+Then run govuk-docker-up, and use the Run and Debug tab and press the play button next to "Attach with rdbg", at which point you'll be able to set breakpoints in your code.
+
+Note: the magic number in the debugPort setting should match the equivalent one in govuk-docker for feedback (by default the debug port creates itself at 12345, but to avoid clashes if running more than one app, we redirect that port to different numbers on the host)


### PR DESCRIPTION
- Adds VS code debugging support to `Feedback` app with govuk-docker.
The debug port is also setup in this [govuk-docker PR](https://github.com/alphagov/govuk-docker/pull/1012).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
