### PR TITLE
Set fallback for url

### DIFF
--- a/app/controllers/contact/govuk/problem_reports_controller.rb
+++ b/app/controllers/contact/govuk/problem_reports_controller.rb
@@ -9,10 +9,11 @@ class Contact::Govuk::ProblemReportsController < ContactController
     attributes = params.merge(technical_attributes)
 
     # Where the 'url' parameter isn't explicitly provided, obtain it
-    # from the HTTP referer. This is an edge case in the app as there
+    # from the HTTP referer and that falls back to the root path if both values are blank.
+    # This is an edge case in the app as there
     # should only be a finite number of places where this occurs.
     # Specifially, the 40X pages on GOV.UK.
-    attributes = attributes.merge(url: request.referer) unless params.key? :url
+    attributes = attributes.merge(url: attributes[:url].presence || request.referer || "/")
 
     ticket = ReportAProblemTicket.new(attributes)
 

--- a/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
+++ b/spec/controllers/contact/govuk/problem_reports_controller_spec.rb
@@ -87,6 +87,24 @@ RSpec.describe Contact::Govuk::ProblemReportsController, type: :controller do
                  }
           end
         end
+
+        describe "no 'url' value or referrer set" do
+          it "should fall back to the root path for the 'url'" do
+            stub_ticket = double("Ticket")
+            expect(ReportAProblemTicket).to receive(:new)
+              .with(hash_including(url: "/"))
+              .and_return(stub_ticket)
+            expect(stub_ticket).to receive(:valid?).and_return(true)
+            expect(stub_ticket).to receive(:save).and_return(true)
+
+            @request.env["HTTP_REFERER"] = nil
+            post :create,
+                 params: {
+                   what_doing: "Nothing",
+                   what_wrong: "Something",
+                 }
+          end
+        end
       end
 
       context "ajax submission" do


### PR DESCRIPTION
- This handles the case where both `url` and `HTTP referrer` are blank by falling back to '/' a root path. This is to ensure that `support-api` receives a valid value for the `path` attribute.

[JIRA ticket](https://gov-uk.atlassian.net/browse/PNP-10074)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
